### PR TITLE
Fix hvm-core library name

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "hvm-core"
+name = "hvm_core"
 path = "src/lib.rs"
 
 [dependencies]


### PR DESCRIPTION
Hyphens are ok in package names, but not in lib names