### PR TITLE
Change tag from u8 to enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ license = "MIT"
 [[bin]]
 name = "hvmc"
 path = "src/main.rs"
+bench = false
 
 [lib]
 name = "hvmc"
 path = "src/lib.rs"
+bench = false
 
 # Benchmark dependencies
 

--- a/README.md
+++ b/README.md
@@ -471,4 +471,13 @@ to pay to gain the ability of computing them with massive parallelism.
 
 ## Contributing
 
-To verify if there's no performance regression, run `cargo bench` before and after your changes. You can run `cargo bench --bench hvm_cpu -- --quick` for a quicker but less accurate benchmark. Inside the `target/criterion/report/index.html` file, you can see the performance of each benchmark.
+To verify if there's no performance regression:
+
+```bash
+git checkout main
+cargo bench -- --save-baseline main # save the unchanged code as "main"
+git checkout <your-branch>
+cargo bench -- --baseline main      # compare your changes with the "main" branch
+```
+
+Inside the `target/criterion/report/index.html` file, you can see graphics of each benchmark.

--- a/benches/hvm_cpu.rs
+++ b/benches/hvm_cpu.rs
@@ -32,7 +32,7 @@ fn load_from_lang(file: &str, size: usize, replace: Option<(&str, &str)>) -> (ru
 
 fn church_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("church");
-  for n in [2, 8, 24] {
+  for n in [20] {
     group.throughput(criterion::Throughput::Elements(n));
     let (book, net) = load_from_lang("./benches/programs/church_mul.hvm", 1 << 12, Some(("{n}", &n.to_string())));
     group.bench_with_input(criterion::BenchmarkId::new("multiplication", n), &n, |b, &_n| {
@@ -50,7 +50,7 @@ fn church_benchmark(c: &mut Criterion) {
 fn tree_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("tree");
   // Allocates a big tree
-  for n in [4, 8, 16] {
+  for n in [12] {
     let (book, net) = load_from_core("./benches/programs/alloc_big_tree.hvmc", 16 << n, Some(("{n}", &n.to_string())));
     group.bench_with_input(criterion::BenchmarkId::new("allocation", n), &n, |b, &_n| {
       b.iter_batched(|| net.clone(), |mut net| black_box(net.normal(&book)), criterion::BatchSize::SmallInput);
@@ -61,14 +61,14 @@ fn tree_benchmark(c: &mut Criterion) {
 fn binary_counter_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("binary-counter");
   // Decrements a BitString until it is zero
-  for n in [4, 8, 16] {
+  for n in [12] {
     let (book, net) = load_from_core("./benches/programs/dec_bits.hvmc", 16 << n, Some(("{n}", &n.to_string())));
     group.bench_with_input(criterion::BenchmarkId::new("single", n), &n, |b, &_n| {
       b.iter_batched(|| net.clone(), |mut net| black_box(net.normal(&book)), criterion::BatchSize::SmallInput);
     });
   }
   // Decrements 2^N BitStrings until they reach zero (ex3)
-  for n in [4, 6, 8] {
+  for n in [6] {
     let (book, net) = load_from_core("./benches/programs/dec_bits_tree.hvmc", 128 << n, Some(("{n}", &n.to_string())));
     group.bench_with_input(criterion::BenchmarkId::new("many", n), &n, |b, &_n| {
       b.iter_batched(|| net.clone(), |mut net| black_box(net.normal(&book)), criterion::BatchSize::SmallInput);
@@ -84,15 +84,43 @@ fn fusion_benchmark(c: &mut Criterion) {
   });
 }
 
+fn interact_benchmark(c: &mut Criterion) {
+  use ast::Tree::*;
+  let mut group = c.benchmark_group("interact");
+  group.sample_size(1000);
+
+  let cases = [
+    ("era-era", (Era, Era)),
+    ("era-con", (Era, Ctr { lab: 0, lft: Era.into(), rgt: Era.into() })),
+    ("con-con", ((Ctr { lab: 0, lft: Era.into(), rgt: Era.into() }), Ctr { lab: 0, lft: Era.into(), rgt: Era.into() })),
+    ("con-dup", ((Ctr { lab: 0, lft: Era.into(), rgt: Era.into() }), Ctr { lab: 2, lft: Era.into(), rgt: Era.into() })),
+  ];
+  
+  for (name, redex) in cases {
+    let mut net = run::Net::new(10);
+    let book = run::Book::new();
+    ast::net_to_runtime(&mut net, &ast::Net { root: Era, rdex: vec![redex] });
+    let (rdx_a, rdx_b) = net.rdex[0];
+    group.bench_function(name, |b| {
+      b.iter_batched(
+        || net.clone(),
+        |mut net| black_box(net.interact(&book, rdx_a, rdx_b)),
+        criterion::BatchSize::SmallInput
+      );
+    });
+  }
+}
+
 criterion_group! {
   name = benches;
   config = Criterion::default()
-    .measurement_time(Duration::from_millis(700))
-    .warm_up_time(Duration::from_millis(300));
+    .measurement_time(Duration::from_millis(1000))
+    .warm_up_time(Duration::from_millis(500));
   targets =
     church_benchmark,
     tree_benchmark,
     binary_counter_benchmark,
     fusion_benchmark,
+    interact_benchmark,
 }
 criterion_main!(benches);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -398,7 +398,7 @@ pub fn tree_to_runtime_go(rt_net: &mut run::Net, tree: &Tree, vars: &mut HashMap
       rt_net.heap.set(val, run::P1, p1);
       let p2 = tree_to_runtime_go(rt_net, &*rgt, vars, Parent::Node { val, port: run::P2 });
       rt_net.heap.set(val, run::P2, p2);
-      run::Ptr::new(*lab + run::CT0, val)
+      run::Ptr::new((*lab + u8::from(run::CT0)).into(), val)
     }
     Tree::Var { nam } => {
       if let Parent::Redex = parent {
@@ -518,7 +518,7 @@ pub fn tree_from_runtime_go(rt_net: &run::Net, ptr: run::Ptr, parent: Parent, va
       let lft = tree_from_runtime_go(rt_net, p1, Parent::Node { val: ptr.val(), port: run::P1 }, vars, fresh);
       let rgt = tree_from_runtime_go(rt_net, p2, Parent::Node { val: ptr.val(), port: run::P2 }, vars, fresh);
       Tree::Ctr {
-        lab: ptr.tag() - run::CT0,
+        lab: (u8::from(ptr.tag()) - u8::from(run::CT0)).into(),
         lft: Box::new(lft),
         rgt: Box::new(rgt),
       }


### PR DESCRIPTION
This PR changes the `Tag` type from an u8 to an enum.
```
church/multiplication/20
  change:   [-13.049% -5.6149% +2.1151%] (p = 0.16 > 0.05)
  No change in performance detected.
church/exponentiation/20
  change:   [-1.8014% -1.4295% -1.0989%] (p = 0.00 < 0.05)
  Performance has improved.
tree/allocation/14
  change: [-2.4150% -2.0382% -1.6717%] (p = 0.00 < 0.05)
  Performance has improved.
binary-counter/single/14
  change: [-6.1013% -5.8894% -5.6712%] (p = 0.00 < 0.05)
  Performance has improved.
binary-counter/many/8
  change: [-5.7278% -5.6630% -5.6022%] (p = 0.00 < 0.05)
  Performance has improved.
fusion/neg/256
  change: [-1.8084% -1.0441% -0.3401%] (p = 0.00 < 0.05)
  Change within noise threshold.
interact/era-era
  change: [-3.7718% -0.9110% +1.0452%] (p = 0.57 > 0.05)
  No change in performance detected.
interact/era-con
  change: [-2.8016% -1.2914% -0.0279%] (p = 0.07 > 0.05)
  No change in performance detected.
interact/con-con
  change: [-2.1584% -0.8527% +0.5961%] (p = 0.24 > 0.05)
  No change in performance detected.
interact/con-dup
  change: [-3.1977% -2.1576% -1.0240%] (p = 0.00 < 0.05)
  Performance has improved.
```