### PR TITLE
Fail parser when not all chars consumed

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -231,8 +231,16 @@ pub fn parse_book(chars: &mut Peekable<Chars>) -> Result<Book, String> {
 }
 
 fn do_parse<T>(code: &str, parse_fn: impl Fn(&mut Peekable<Chars>) -> Result<T, String>) -> T {
-  match parse_fn(&mut code.chars().peekable()) {
-    Ok(result) => result,
+  let chars = &mut code.chars().peekable();
+  match parse_fn(chars) {
+    Ok(result) => {
+      if let None = chars.next() {
+        result
+      } else {
+        eprintln!("Unable to parse the whole input. Is this not an hvmc file?");
+        std::process::exit(1);
+      }
+    }
     Err(err) => {
       eprintln!("{}", err);
       std::process::exit(1);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -234,7 +234,7 @@ fn do_parse<T>(code: &str, parse_fn: impl Fn(&mut Peekable<Chars>) -> Result<T, 
   let chars = &mut code.chars().peekable();
   match parse_fn(chars) {
     Ok(result) => {
-      if let None = chars.next() {
+      if chars.next().is_none() {
         result
       } else {
         eprintln!("Unable to parse the whole input. Is this not an hvmc file?");

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,10 @@ fn print_stats(net: &run::Net, start_time: std::time::Instant) {
 
 // Load file and generate net
 fn load<'a>(data: &'a run::Data, file: &str) -> (run::Book, run::Net<'a>) {
-  let file = fs::read_to_string(file).unwrap();
+    let Ok(file) = fs::read_to_string(file) else {
+        eprintln!("Input file not found");
+        std::process::exit(1);
+    };
   let book = ast::book_to_runtime(&ast::do_parse_book(&file));
   let mut net = run::Net::new(&data);
   net.boot(ast::name_to_val("main") as run::Loc);


### PR DESCRIPTION
With this, we get an error when accidentally reading non-hvmc files instead of parsing as `@main = @main`.