### PR TITLE
Optimize OP2 rewrites if both arguments are NUM

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -827,12 +827,22 @@ impl<'a> Net<'a> {
 
   pub fn op2n(&mut self, a: Ptr, b: Ptr) {
     self.rwts.oper += 1;
-    let loc0 = self.alloc();
     let a1 = Ptr::new(VR1, 0, a.loc());
     let a2 = Ptr::new(VR2, 0, a.loc());
-    self.heap.set(loc0, P1, b);
-    self.half_atomic_link(a2, Ptr::new(VR2, 0, loc0));
-    self.half_atomic_link(a1, Ptr::new(OP1, a.lab(), loc0));
+    let x = self.get_target(a1);
+    if x.tag() == NUM {
+      self.set_target(a1, NULL);
+      let op = a.lab();
+      let v0 = x.val();
+      let v1 = b.val();
+      let v2 = self.op(op, v1, v0);
+      self.half_atomic_link(a2, Ptr::big(NUM, v2));
+    } else {
+      let loc0 = self.alloc();
+      self.heap.set(loc0, P1, b);
+      self.half_atomic_link(a2, Ptr::new(VR2, 0, loc0));
+      self.half_atomic_link(a1, Ptr::new(OP1, a.lab(), loc0));
+    }
   }
 
   pub fn op1n(&mut self, a: Ptr, b: Ptr) {


### PR DESCRIPTION
If P1 of an OP2 node is a NUM value, go ahead and do the op without creating an OP1 reduction.

This PR is for documentation purposes. This optimization has little effect on performance regression tests. On the radix sort example, it does eliminate a significant number of OP rewrites, but the overall execution time is not improved much at all.