### PR TITLE
merge op2 and op1

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -68,11 +68,11 @@ fn compile_def(code: &mut String, host: &Host, name: &str, instr: &[Instruction]
       Instruction::Ctr { lab, trg, lft, rgt } => {
         writeln!(code, "let ({lft}, {rgt}) = net.do_ctr({lab}, {trg});")
       }
-      Instruction::Op2 { op, trg, lft, rgt } => {
-        writeln!(code, "let ({lft}, {rgt}) = net.do_op2({op:?}, {trg});")
+      Instruction::Op { op, trg, rhs, out } => {
+        writeln!(code, "let ({rhs}, {out}) = net.do_op({op:?}, {trg});")
       }
-      Instruction::Op1 { op, num, trg, rgt } => {
-        writeln!(code, "let {rgt} = net.do_op1({op:?}, {num}, {trg});")
+      Instruction::OpNum { op, trg, rhs, out } => {
+        writeln!(code, "let {out} = net.do_op_num({op:?}, {trg}, {rhs});")
       }
       Instruction::Mat { trg, lft, rgt } => {
         writeln!(code, "let ({lft}, {rgt}) = net.do_mat({trg});")

--- a/src/host/calc_labels.rs
+++ b/src/host/calc_labels.rs
@@ -185,8 +185,7 @@ impl<'b, F: FnMut(&'b str) -> LabSet> State<'b, F> {
           usize::MAX
         }
       }
-      Tree::Op1 { rgt, .. } => self.visit_tree(rgt, depth, out),
-      Tree::Op2 { lft, rgt, .. } | Tree::Mat { sel: lft, ret: rgt } => {
+      Tree::Op { rhs: lft, out: rgt, .. } | Tree::Mat { sel: lft, ret: rgt } => {
         usize::min(self.visit_tree(lft, depth, out.as_deref_mut()), self.visit_tree(rgt, depth, out.as_deref_mut()))
       }
     })

--- a/src/host/encode_def.rs
+++ b/src/host/encode_def.rs
@@ -84,17 +84,18 @@ pub(crate) fn ast_net_to_instructions<F: FnMut(&str) -> Port>(net: &Net, get_def
           self.visit_tree(lft, l);
           self.visit_tree(rgt, r);
         }
-        Tree::Op2 { opr, lft, rgt } => {
-          let l = self.id();
-          let r = self.id();
-          self.instr.push(Instruction::Op2 { op: *opr, trg, lft: l, rgt: r });
-          self.visit_tree(lft, l);
-          self.visit_tree(rgt, r);
-        }
-        Tree::Op1 { opr, lft, rgt } => {
-          let r = self.id();
-          self.instr.push(Instruction::Op1 { op: *opr, num: *lft, trg, rgt: r });
-          self.visit_tree(rgt, r);
+        Tree::Op { op, rhs, out } => {
+          if let Tree::Num { val } = &**rhs {
+            let o = self.id();
+            self.instr.push(Instruction::OpNum { op: *op, rhs: *val, trg, out: o });
+            self.visit_tree(out, o);
+          } else {
+            let r = self.id();
+            let o = self.id();
+            self.instr.push(Instruction::Op { op: *op, trg, rhs: r, out: o });
+            self.visit_tree(rhs, r);
+            self.visit_tree(out, o);
+          }
         }
         Tree::Mat { sel, ret } => {
           let l = self.id();

--- a/src/host/encode_net.rs
+++ b/src/host/encode_net.rs
@@ -46,13 +46,9 @@ impl<'c, 'n, M: Mode> EncodeState<'c, 'n, M> {
         self.encode(l, lft);
         self.encode(r, rgt);
       }
-      Tree::Op2 { opr, lft, rgt } => {
-        let (l, r) = self.net.do_op2(*opr, trg);
+      Tree::Op { op, rhs: lft, out: rgt } => {
+        let (l, r) = self.net.do_op(*op, trg);
         self.encode(l, lft);
-        self.encode(r, rgt);
-      }
-      Tree::Op1 { opr, lft, rgt } => {
-        let r = self.net.do_op1(*opr, *lft, trg);
         self.encode(r, rgt);
       }
       Tree::Mat { sel, ret } => {

--- a/src/host/readback.rs
+++ b/src/host/readback.rs
@@ -57,15 +57,10 @@ impl<'a> ReadbackState<'a> {
       Tag::Ref if port == Port::ERA => Tree::Era,
       Tag::Ref => Tree::Ref { nam: self.host.back[&port.addr()].clone() },
       Tag::Num => Tree::Num { val: port.num() },
-      Tag::Op2 => {
-        let opr = port.op();
+      Tag::Op => {
+        let op = port.op();
         let node = port.traverse_node();
-        Tree::Op2 { opr, lft: Box::new(self.read_wire(node.p1)), rgt: Box::new(self.read_wire(node.p2)) }
-      }
-      Tag::Op1 => {
-        let opr = port.op();
-        let node = port.traverse_op1();
-        Tree::Op1 { opr, lft: node.num.num(), rgt: Box::new(self.read_wire(node.p2)) }
+        Tree::Op { op, rhs: Box::new(self.read_wire(node.p1)), out: Box::new(self.read_wire(node.p2)) }
       }
       Tag::Ctr => {
         let node = port.traverse_node();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,6 +3,12 @@ use crate::util::bi_enum;
 bi_enum! {
   #[repr(u16)]
   /// A native operation on 60-bit integers.
+  ///
+  /// Each operation has a swapped counterpart (accessible with `.swap()`),
+  /// where the order of the operands is swapped.
+  ///
+  /// Operations without an already-named counterpart (e.g. `Add <-> Add` and
+  /// `Lt <-> Gt`) are suffixed with `$`/`S`: `(-$ 1 2) = (- 2 1) = 1`.
   #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
   pub enum Op {
     "+":   Add  = 0,
@@ -32,6 +38,9 @@ bi_enum! {
 use Op::*;
 
 impl Op {
+  /// Returns this operation's swapped counterpart.
+  ///
+  /// For all `op, a, b`, `op.swap().op(a, b) == op.op(b, a)`.
   #[inline]
   pub fn swap(self) -> Self {
     match self {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -5,37 +5,71 @@ bi_enum! {
   /// A native operation on 60-bit integers.
   #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
   pub enum Op {
-    "+":  Add = 0,
-    "-":  Sub = 1,
-    "*":  Mul = 2,
-    "/":  Div = 3,
-    "%":  Mod = 4,
-    "==": Eq  = 5,
-    "!=": Ne  = 6,
-    "<":  Lt  = 7,
-    ">":  Gt  = 8,
-    "<=": Lte = 9,
-    ">=": Gte = 10,
-    "&":  And = 11,
-    "|":  Or  = 12,
-    "^":  Xor = 13,
-    "<<": Lsh = 14,
-    ">>": Rsh = 15,
-    "!":  Not = 16,
+    "+":   Add  = 0,
+    "-":   Sub  = 1,
+    "-$":  SubS = 2,
+    "*":   Mul  = 3,
+    "/":   Div  = 4,
+    "/$":  DivS = 5,
+    "%":   Mod  = 6,
+    "%$":  ModS = 7,
+    "==":  Eq   = 8,
+    "!=":  Ne   = 9,
+    "<":   Lt   = 10,
+    ">":   Gt   = 11,
+    "<=":  Lte  = 12,
+    ">=":  Gte  = 13,
+    "&":   And  = 14,
+    "|":   Or   = 15,
+    "^":   Xor  = 16,
+    "<<":  Shl  = 17,
+    "<<$": ShlS = 18,
+    ">>":  Shr  = 19,
+    ">>$": ShrS = 20,
   }
 }
 
+use Op::*;
+
 impl Op {
   #[inline]
+  pub fn swap(self) -> Self {
+    match self {
+      Add => Add,
+      Sub => SubS,
+      SubS => Sub,
+      Mul => Mul,
+      Div => DivS,
+      DivS => Div,
+      Mod => ModS,
+      ModS => Mod,
+      Eq => Eq,
+      Ne => Ne,
+      Lt => Gt,
+      Gt => Lt,
+      Lte => Gte,
+      Gte => Lte,
+      And => And,
+      Or => Or,
+      Xor => Xor,
+      Shl => ShlS,
+      ShlS => Shl,
+      Shr => ShrS,
+      ShrS => Shr,
+    }
+  }
+  #[inline]
   pub fn op(self, a: u64, b: u64) -> u64 {
-    use Op::*;
     const U60: u64 = 0xFFF_FFFF_FFFF_FFFF;
     match self {
       Add => a.wrapping_add(b) & U60,
       Sub => a.wrapping_sub(b) & U60,
+      SubS => b.wrapping_sub(a) & U60,
       Mul => a.wrapping_mul(b) & U60,
       Div => a.checked_div(b).unwrap_or(0),
+      DivS => b.checked_div(a).unwrap_or(0),
       Mod => a.checked_rem(b).unwrap_or(0),
+      ModS => b.checked_rem(a).unwrap_or(0),
       Eq => (a == b) as u64,
       Ne => (a != b) as u64,
       Lt => (a < b) as u64,
@@ -45,9 +79,10 @@ impl Op {
       And => a & b,
       Or => a | b,
       Xor => a ^ b,
-      Lsh => (a << b) & U60,
-      Rsh => a >> b,
-      Not => !a,
+      Shl => (a << b) & U60,
+      ShlS => (b << a) & U60,
+      Shr => a >> b,
+      ShrS => b >> a,
     }
   }
 }

--- a/src/run/def.rs
+++ b/src/run/def.rs
@@ -239,14 +239,14 @@ impl AsDef for InterpretedDef {
             trgs.set_trg(lft, l);
             trgs.set_trg(rgt, r);
           }
-          Instruction::Op2 { op, trg, lft, rgt } => {
-            let (l, r) = net.do_op2(op, trgs.get_trg(trg));
-            trgs.set_trg(lft, l);
-            trgs.set_trg(rgt, r);
+          Instruction::Op { op, trg, rhs, out } => {
+            let (r, o) = net.do_op(op, trgs.get_trg(trg));
+            trgs.set_trg(rhs, r);
+            trgs.set_trg(out, o);
           }
-          Instruction::Op1 { op, trg, num, rgt } => {
-            let r = net.do_op1(op, num, trgs.get_trg(trg));
-            trgs.set_trg(rgt, r);
+          Instruction::OpNum { op, trg, rhs: lhs, out } => {
+            let o = net.do_op_num(op, trgs.get_trg(trg), lhs);
+            trgs.set_trg(out, o);
           }
           Instruction::Mat { trg, lft, rgt } => {
             let (l, r) = net.do_mat(trgs.get_trg(trg));

--- a/src/run/interact.rs
+++ b/src/run/interact.rs
@@ -16,14 +16,10 @@ impl<'a, M: Mode> Net<'a, M> {
       // comm 2/2
       (Ctr, Mat) if a.lab() != 0 => self.comm22(a, b),
       (Mat, Ctr) if b.lab() != 0 => self.comm22(a, b),
-      (Ctr, Op2) | (Op2, Ctr) => self.comm22(a, b),
+      (Ctr, Op) | (Op, Ctr) => self.comm22(a, b),
       (Ctr, Ctr) if a.lab() != b.lab() => self.comm22(a, b),
-      // comm 1/2
-      (Op1, Ctr) => self.comm12(a, b),
-      (Ctr, Op1) => self.comm12(b, a),
       // anni
-      (Mat, Mat) | (Op2, Op2) | (Ctr, Ctr) => self.anni2(a, b),
-      (Op1, Op1) => self.anni1(a, b),
+      (Mat, Mat) | (Op, Op) | (Ctr, Ctr) => self.anni2(a, b),
       // comm 2/0
       (Ref, Ctr) if b.lab() >= a.lab() => self.comm02(a, b),
       (Ctr, Ref) if a.lab() >= b.lab() => self.comm02(b, a),
@@ -35,21 +31,15 @@ impl<'a, M: Mode> Net<'a, M> {
       (Ref, _) => self.call(a, b),
       (_, Ref) => self.call(b, a),
       // native ops
-      (Op2, Num) => self.op2_num(a, b),
-      (Num, Op2) => self.op2_num(b, a),
-      (Op1, Num) => self.op1_num(a, b),
-      (Num, Op1) => self.op1_num(b, a),
+      (Op, Num) => self.op_num(a, b),
+      (Num, Op) => self.op_num(b, a),
       (Mat, Num) => self.mat_num(a, b),
       (Num, Mat) => self.mat_num(b, a),
       // todo: what should the semantics of these be?
       (Mat, Ctr) // b.lab() == 0
       | (Ctr, Mat) // a.lab() == 0
-      | (Op2, Op1)
-      | (Op1, Op2)
-      | (Op2, Mat)
-      | (Mat, Op2)
-      | (Op1, Mat)
-      | (Mat, Op1) => unimplemented!("{:?}-{:?}", a.tag(), b.tag()),
+      | (Op, Mat)
+      | (Mat, Op) => unimplemented!("{:?}-{:?}", a.tag(), b.tag()),
     }
   }
 
@@ -182,136 +172,6 @@ impl<'a, M: Mode> Net<'a, M> {
     self.link_wire_port(b.p2, a);
   }
 
-  /// Annihilates two unary agents.
-  ///
-  /// ```text
-  ///  
-  ///         a2 |
-  ///            |   n
-  ///           _|___|_
-  ///           \     /
-  ///         a  \op1/
-  ///             \ /
-  ///              |
-  ///             / \
-  ///         b  /op1\
-  ///           /_____\
-  ///            |   |
-  ///            m   |
-  ///                | b2
-  ///
-  /// --------------------------- anni1
-  ///
-  ///         a2 |
-  ///            |
-  ///            |
-  ///             \
-  ///              \
-  ///               \
-  ///                |
-  ///                |
-  ///                | b2
-  ///  
-  /// ```
-  #[inline(never)]
-  pub fn anni1(&mut self, a: Port, b: Port) {
-    trace!(self.tracer, a, b);
-    self.rwts.anni += 1;
-    let a = a.consume_op1();
-    let b = b.consume_op1();
-    self.link_wire_wire(a.p2, b.p2);
-  }
-
-  /// Commutes a unary agent and a unary agent.
-  ///
-  /// ```text
-  ///  
-  ///         a2 |   n
-  ///           _|___|_
-  ///           \     /
-  ///         a  \op1/
-  ///             \ /
-  ///              |
-  ///             /#\
-  ///         b  /###\
-  ///           /#####\
-  ///            |   |
-  ///         b1 |   | b2
-  ///
-  /// --------------------------- comm12
-  ///
-  ///     a2 |
-  ///        |
-  ///       /#\
-  ///  B2  /###\
-  ///     /#####\
-  ///      |   \
-  ///   p1 | p2 \
-  ///      |     \
-  ///      |      \
-  ///      |       \
-  ///   p2 |   n    \ p2 n
-  ///     _|___|_   _\___|_
-  ///     \     /   \     /
-  ///  A1  \op1/     \op1/  A2
-  ///       \ /       \ /
-  ///        |         |
-  ///     b1 |         | b2
-  ///  
-  /// ```
-  #[inline(never)]
-  pub fn comm12(&mut self, a: Port, b: Port) {
-    trace!(self.tracer, a, b);
-    self.rwts.comm += 1;
-
-    let a = a.consume_op1();
-    let b = b.consume_node();
-
-    let A1 = self.create_node(Op1, a.op as Lab);
-    let A2 = self.create_node(Op1, a.op as Lab);
-    let B2 = self.create_node(b.tag, b.lab);
-
-    trace!(self.tracer, B2.p0, A1.p0, A2.p0);
-    self.link_port_port(A1.p1, a.num.clone());
-    self.link_port_port(A1.p2, B2.p1);
-    self.link_port_port(A2.p1, a.num.clone());
-    self.link_port_port(A2.p2, B2.p2);
-
-    trace!(self.tracer);
-    self.link_wire_port(a.p2, B2.p0);
-    self.link_wire_port(b.p1, A1.p0);
-    self.link_wire_port(b.p2, A2.p0);
-  }
-
-  /// Commutes a nilary agent and a unary agent.
-  ///
-  /// ```text
-  ///  
-  ///         a  (---)
-  ///              |
-  ///              |
-  ///             / \
-  ///         b  /op1\
-  ///           /_____\
-  ///            |   |
-  ///            n   |
-  ///                | b2
-  ///
-  /// --------------------------- comm02
-  ///
-  ///              (---) a
-  ///                |
-  ///                | b2
-  ///  
-  /// ```
-  #[inline(never)]
-  pub fn comm01(&mut self, a: Port, b: Port) {
-    trace!(self.tracer, a, b);
-    self.rwts.comm += 1;
-    let b = b.consume_op1();
-    self.link_wire_port(b.p2, a);
-  }
-
   /// Interacts a number and a numeric match node.
   ///
   /// ```text
@@ -369,77 +229,45 @@ impl<'a, M: Mode> Net<'a, M> {
   /// Interacts a number and a binary numeric operation node.
   ///
   /// ```text
-  ///  
-  ///         b   (n)    
-  ///              |      
-  ///              |       
-  ///             / \       
-  ///         a  /op2\       
-  ///           /_____\       
-  ///            |   |         
-  ///         a1 |   | a2       
-  ///                            
-  /// --------------------------- op2_num
-  ///           _ _ _
-  ///         /       \
-  ///        |   n     |   
-  ///       _|___|_    |   
-  ///       \     /    |   
-  ///     x  \op1/     |   
-  ///         \ /      |   
-  ///          |       |   
-  ///       a1 |       | a2  
-  ///  
+  ///                             |  
+  ///         b   (n)             |         b   (n)    
+  ///              |              |              |      
+  ///              |              |              |       
+  ///             / \             |             / \       
+  ///         a  /op \            |         a  /op \       
+  ///           /_____\           |           /_____\       
+  ///            |   |            |            |   |         
+  ///           (m)  | a2         |         a1 |   | a2       
+  ///                             |                            
+  /// --------------------------- | --------------------------- op_num
+  ///                             |           _ _ _
+  ///                             |         /       \
+  ///                             |        |  (n)    |   
+  ///                             |       _|___|_    |   
+  ///                             |       \     /    |   
+  ///                             |     x  \op$/     |   
+  ///            (n op m)         |         \ /      |   
+  ///                |            |          |       |   
+  ///                | a2         |       a1 |       | a2  
+  ///                             |  
   /// ```
   #[inline(never)]
-  pub fn op2_num(&mut self, a: Port, b: Port) {
+  pub fn op_num(&mut self, a: Port, b: Port) {
     trace!(self.tracer, a, b);
-    self.rwts.oper += 1;
     let a = a.consume_node();
+    let op = unsafe { Op::from_unchecked(a.lab) };
     let a1 = a.p1.load_target();
     if a1.tag() == Num {
-      // skip creating the Op1 node if it will instantly interact
       self.rwts.oper += 1;
-      let out = unsafe { Op::from_unchecked(a.lab) }.op(b.num(), a1.num());
+      let out = op.op(b.num(), a1.num());
       self.link_wire_port(a.p2, Port::new_num(out));
     } else {
-      let x = self.create_node(Op1, a.lab);
+      let op = op.swap();
+      let x = self.create_node(Op, op as u16);
       trace!(self.tracer, x.p0);
       self.link_port_port(x.p1, b);
       self.link_wire_port(a.p2, x.p2);
       self.link_wire_port(a.p1, x.p0);
     }
-  }
-
-  /// Interacts a number and a unary numeric operation node.
-  ///
-  /// ```text
-  ///  
-  ///         b   (m)    
-  ///              |      
-  ///              |       
-  ///             / \       
-  ///         a  /op1\       
-  ///           /_____\       
-  ///            |   |         
-  ///            n   |         
-  ///                | a2       
-  ///                            
-  /// --------------------------- op1_num
-  ///                       
-  ///          (n opr m)
-  ///              |         
-  ///              | a2
-  ///  
-  /// ```
-  #[inline(never)]
-  pub fn op1_num(&mut self, a: Port, b: Port) {
-    trace!(self.tracer, a, b);
-    self.rwts.oper += 1;
-    let a = a.consume_op1();
-    let n = a.num.num();
-    let m = b.num();
-    let out = a.op.op(n, m);
-    self.link_wire_port(a.p2, Port::new_num(out));
   }
 }

--- a/src/run/net.rs
+++ b/src/run/net.rs
@@ -130,9 +130,7 @@ impl<'a, M: Mode> Net<'a, M> {
       let next = self.weak_normal(prev, root.clone());
       trace!(self.tracer, "got", next);
       if next.is_full_node() {
-        if next.tag() != Op1 {
-          visit.push(Port::new_var(next.addr()));
-        }
+        visit.push(Port::new_var(next.addr()));
         visit.push(Port::new_var(next.addr().other_half()));
       }
     }

--- a/src/run/node.rs
+++ b/src/run/node.rs
@@ -8,13 +8,6 @@ pub struct TraverseNode {
   pub p2: Wire,
 }
 
-/// See [`Port::traverse_op1`].
-pub struct TraverseOp1 {
-  pub op: Op,
-  pub num: Port,
-  pub p2: Wire,
-}
-
 impl Port {
   #[inline(always)]
   pub fn consume_node(self) -> TraverseNode {
@@ -29,22 +22,6 @@ impl Port {
       p1: Wire::new(self.addr()),
       p2: Wire::new(self.addr().other_half()),
     }
-  }
-
-  #[inline(always)]
-  pub fn consume_op1(self) -> TraverseOp1 {
-    let op = self.op();
-    let s = self.consume_node();
-    let num = s.p1.swap_target(Port::FREE);
-    TraverseOp1 { op, num, p2: s.p2 }
-  }
-
-  #[inline(always)]
-  pub fn traverse_op1(self) -> TraverseOp1 {
-    let op = self.op();
-    let s = self.traverse_node();
-    let num = s.p1.load_target();
-    TraverseOp1 { op, num, p2: s.p2 }
   }
 }
 

--- a/src/run/port.rs
+++ b/src/run/port.rs
@@ -56,7 +56,7 @@ bi_enum! {
     ///
     /// The 4th bit from the bottom is currently unused in this port.
     Num = 3,
-    /// An `Op2` port represents the principal port of an Op2 node.
+    /// An `Op` port represents the principal port of an Op node.
     ///
     /// The label of this port is the corresponding operation, which can be
     /// accessed with [`Port::op`].
@@ -64,17 +64,7 @@ bi_enum! {
     /// The address of this port is the address of a two-word allocation,
     /// storing the targets of the wires connected to the two auxiliary ports of
     /// this node.
-    Op2 = 4,
-    /// An `Op1` port represents the principal port of an Op1 node.
-    ///
-    /// The label of this port is the corresponding operation, which can be
-    /// accessed with [`Port::op`].
-    ///
-    /// The address of this port is the address of a two-word allocation. The
-    /// first word in this allocation stores the first operand as a `Num` port,
-    /// and the second word stores the target of the wire connected to the
-    /// auxiliary port of this node.
-    Op1 = 5,
+    Op = 4,
     /// A `Mat` port represents the principal port of a Mat node.
     ///
     /// The address of this port is the address of a two-word allocation,
@@ -107,7 +97,7 @@ impl fmt::Debug for Port {
       _ => match self.tag() {
         Num => write!(f, "[Num {}]", self.num()),
         Var | Red | Mat => write!(f, "[{:?} {:?}]", self.tag(), self.addr()),
-        Op2 | Op1 | Ctr | Ref => write!(f, "[{:?} {:?} {:?}]", self.tag(), self.lab(), self.addr()),
+        Op | Ctr | Ref => write!(f, "[{:?} {:?} {:?}]", self.tag(), self.lab(), self.addr()),
       },
     }
   }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -91,7 +91,7 @@ impl<F: Fn(Wire) + Send + Sync + 'static> AsDef for ActiveLogDef<F> {
         }
       }
       Tag::Ref | Tag::Num | Tag::Var => net.link_port_port(def.data.out, port),
-      tag @ (Tag::Op2 | Tag::Op1 | Tag::Mat | Tag::Ctr) => {
+      tag @ (Tag::Op | Tag::Mat | Tag::Ctr) => {
         let old = port.consume_node();
         let new = net.create_node(tag, old.lab);
         net.link_port_port(def.data.out, new.p0);

--- a/src/util/apply_tree.rs
+++ b/src/util/apply_tree.rs
@@ -44,11 +44,8 @@ impl Tree {
         }
       }
       // Recurse on children
-      Tree::Ctr { lft, rgt, .. } | Tree::Op2 { lft, rgt, .. } | Tree::Mat { sel: lft, ret: rgt } => {
+      Tree::Ctr { lft, rgt, .. } | Tree::Op { rhs: lft, out: rgt, .. } | Tree::Mat { sel: lft, ret: rgt } => {
         lft.ensure_no_conflicts(fresh);
-        rgt.ensure_no_conflicts(fresh);
-      }
-      Tree::Op1 { rgt, .. } => {
         rgt.ensure_no_conflicts(fresh);
       }
       Tree::Era | Tree::Num { .. } | Tree::Ref { .. } => {}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -98,7 +98,7 @@ fn test_cli_run_with_args() {
       &arithmetic_program,
       "#64"
     ]).unwrap().1,
-    @"({5 <64/ a> <64% b>} [a b])"
+    @"({5 </$ #64 a> <%$ #64 b>} [a b])"
   );
 
   // Test passing all arguments.
@@ -239,7 +239,7 @@ fn test_apply_tree() {
   );
   assert_display_snapshot!(
     eval_with_args("(<* a b> (a b))", &vec!["#2"]),
-    @"(<2* a> a)"
+    @"(<* #2 a> a)"
   );
 }
 

--- a/tests/numeric.rs
+++ b/tests/numeric.rs
@@ -18,7 +18,7 @@ fn test_add() {
   let net = op_net(10, Op::Add, 2);
   let (rwts, net) = normal(net, 16);
   assert_snapshot!(Net::to_string(&net), @"#12");
-  assert_debug_snapshot!(rwts.total(), @"3");
+  assert_debug_snapshot!(rwts.total(), @"2");
 }
 
 #[test]
@@ -99,23 +99,15 @@ fn test_xor() {
 }
 
 #[test]
-fn test_not() {
-  let net = op_net(0, Op::Not, 256);
-  let (rwts, net) = normal(net, 16);
-  assert_snapshot!(Net::to_string(&net), @"#1152921504606846975");
-  assert_debug_snapshot!(rwts.total(), @"3");
-}
-
-#[test]
 fn test_lsh() {
-  let net = op_net(10, Op::Lsh, 2);
+  let net = op_net(10, Op::Shl, 2);
   let (_rwts, net) = normal(net, 16);
   assert_snapshot!(Net::to_string(&net), @"#40");
 }
 
 #[test]
 fn test_rsh() {
-  let net = op_net(10, Op::Rsh, 2);
+  let net = op_net(10, Op::Shr, 2);
   let (_rwts, net) = normal(net, 16);
   assert_snapshot!(Net::to_string(&net), @"#2");
 }
@@ -125,5 +117,5 @@ fn test_div_by_0() {
   let net = op_net(9, Op::Div, 0);
   let (rwts, net) = normal(net, 16);
   assert_snapshot!(Net::to_string(&net), @"#0");
-  assert_debug_snapshot!(rwts.total(), @"3");
+  assert_debug_snapshot!(rwts.total(), @"2");
 }

--- a/tests/snapshots/tests__run@chained_ops.hvmc.snap
+++ b/tests/snapshots/tests__run@chained_ops.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/chained_ops.hvmc
 ---
 #7184190578800
-RWTS   :              47
+RWTS   :              27
 - ANNI :               2
 - COMM :               4
 - ERAS :               0
 - DREF :               1
-- OPER :              40
+- OPER :              20

--- a/tests/snapshots/tests__run@machine_u32__num_add.hvmc.snap
+++ b/tests/snapshots/tests__run@machine_u32__num_add.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/machine_u32/num_add.hvmc
 ---
 #223
-RWTS   :               6
+RWTS   :               5
 - ANNI :               2
 - COMM :               0
 - ERAS :               0
 - DREF :               2
-- OPER :               2
+- OPER :               1

--- a/tests/snapshots/tests__run@sort__bitonic__bitonic_sort_lam.hvmc.snap
+++ b/tests/snapshots/tests__run@sort__bitonic__bitonic_sort_lam.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/sort/bitonic/bitonic_sort_lam.hvmc
 ---
 #523776
-RWTS   :       2_323_894
+RWTS   :       2_263_482
 - ANNI :       1_344_981
 - COMM :          96_766
 - ERAS :         222_714
 - DREF :         508_402
-- OPER :         151_031
+- OPER :          90_619

--- a/tests/snapshots/tests__run@sort__merge__merge_sort.hvmc.snap
+++ b/tests/snapshots/tests__run@sort__merge__merge_sort.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/sort/merge/merge_sort.hvmc
 ---
 {8 * {8 {14 {8 * {8 {14 {8 {10 #3 a} {8 * a}} {12 {8 {10 #2 b} {8 * b}} c}} c}} {12 {8 * {8 {14 {8 {10 #1 d} {8 * d}} {12 {8 {10 #0 e} {8 * e}} f}} f}} g}} g}}
-RWTS   :             434
+RWTS   :             425
 - ANNI :              64
 - COMM :             242
 - ERAS :              79
 - DREF :              24
-- OPER :              25
+- OPER :              16

--- a/tests/snapshots/tests__run@sort__radix__radix_sort_lam.hvmc.snap
+++ b/tests/snapshots/tests__run@sort__radix__radix_sort_lam.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: examples/sort/radix/radix_sort_lam.hvmc
 ---
 #549755289600
-RWTS   :   1_505_755_139
+RWTS   :   1_473_249_270
 - ANNI :     818_937_828
 - COMM :      28_311_560
 - ERAS :     251_658_239
 - DREF :     314_572_799
-- OPER :      92_274_713
+- OPER :      59_768_844

--- a/tests/snapshots/tests__run@stress_tests__apelacion.hvmc.snap
+++ b/tests/snapshots/tests__run@stress_tests__apelacion.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/stress_tests/apelacion.hvmc
 ---
 #31999968000000
-RWTS   :   1_524_001_713
+RWTS   :   1_397_001_650
 - ANNI :     508_000_698
 - COMM :     254_000_063
 - ERAS :     127_000_254
 - DREF :     254_000_318
-- OPER :     381_000_380
+- OPER :     254_000_317

--- a/tests/snapshots/tests__run@stress_tests__fib_rec.hvmc.snap
+++ b/tests/snapshots/tests__run@stress_tests__fib_rec.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/stress_tests/fib_rec.hvmc
 ---
 #1346269
-RWTS   :      35_759_994
+RWTS   :      34_413_726
 - ANNI :      13_266_266
 - COMM :       2_178_308
 - ERAS :       5_702_885
 - DREF :       7_049_154
-- OPER :       7_563_381
+- OPER :       6_217_113

--- a/tests/snapshots/tests__run@stress_tests__sum_rec.hvmc.snap
+++ b/tests/snapshots/tests__run@stress_tests__sum_rec.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/stress_tests/sum_rec.hvmc
 ---
 #67108864
-RWTS   :   1_207_959_540
+RWTS   :   1_140_850_677
 - ANNI :     469_762_043
 - COMM :      67_108_863
 - ERAS :     134_217_727
 - DREF :     268_435_454
-- OPER :     268_435_453
+- OPER :     201_326_590

--- a/tests/snapshots/tests__run@stress_tests__sum_tail.hvmc.snap
+++ b/tests/snapshots/tests__run@stress_tests__sum_tail.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/stress_tests/sum_tail.hvmc
 ---
 #49999995000000
-RWTS   :     120_000_007
+RWTS   :     110_000_007
 - ANNI :      40_000_003
 - COMM :      20_000_000
 - ERAS :      10_000_001
 - DREF :      20_000_002
-- OPER :      30_000_001
+- OPER :      20_000_001

--- a/tests/snapshots/tests__run@stress_tests__sum_tree.hvmc.snap
+++ b/tests/snapshots/tests__run@stress_tests__sum_tree.hvmc.snap
@@ -4,9 +4,9 @@ expression: output
 input_file: tests/programs/stress_tests/sum_tree.hvmc
 ---
 #16777216
-RWTS   :     754_974_689
+RWTS   :     738_197_474
 - ANNI :     335_544_307
 - COMM :      83_886_075
 - ERAS :     100_663_292
 - DREF :     167_772_154
-- OPER :      67_108_861
+- OPER :      50_331_646


### PR DESCRIPTION
This gets rid of Op1 nodes, and simply uses Op2 nodes with a swapped operation.

This is in preparation for n-ary nodes, where we need to save a tag.

This reduces the rewrite count of many programs. `x & #1 ~ <+ #2 x>` is now 1 rewrite, instead of 2; this is needed to make the rewrite count deterministic. (It is somewhat unfortunate that this means that `#1 ~ <+ x y>` is 0 rewrites, but I believe this path is the least bad.)