### PR TITLE
fix ooms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hvm-core"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "arrayvec",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvm-core"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 description = "HVM-Core is a massively parallel Interaction Combinator evaluator."
 license = "MIT"

--- a/cspell.json
+++ b/cspell.json
@@ -10,6 +10,7 @@
     "combinators",
     "condvar",
     "ctrs",
+    "deque",
     "dereferencable",
     "dref",
     "dups",

--- a/src/host/readback.rs
+++ b/src/host/readback.rs
@@ -18,8 +18,7 @@ impl Host {
     let mut net = Net::default();
 
     net.root = state.read_wire(rt_net.root.clone());
-
-    for (a, b) in &rt_net.redexes {
+    for (a, b) in rt_net.redexes.iter() {
       net.redexes.push((state.read_port(a.clone(), None), state.read_port(b.clone(), None)))
     }
 

--- a/src/run/instruction.rs
+++ b/src/run/instruction.rs
@@ -121,6 +121,7 @@ impl<'a, M: Mode> Net<'a, M> {
     // TODO: fast copy?
     } else if false && !M::LAZY && port.tag() == Num || port.tag() == Ref && lab >= port.lab() {
       self.rwts.comm += 1;
+      self.free_trg(trg);
       (Trg::port(port.clone()), Trg::port(port))
     } else {
       let n = self.create_node(Ctr, lab);
@@ -140,6 +141,7 @@ impl<'a, M: Mode> Net<'a, M> {
       n.p1.wire().set_target(Port::new_num(port.num()));
       (Trg::port(n.p0), Trg::port(n.p2))
     } else if !M::LAZY && port == Port::ERA {
+      self.free_trg(trg);
       (Trg::port(Port::ERA), Trg::port(Port::ERA))
     } else {
       let n = self.create_node(Op, op as Lab);
@@ -157,6 +159,7 @@ impl<'a, M: Mode> Net<'a, M> {
       self.free_trg(trg);
       Trg::port(Port::new_num(op.op(port.num(), rhs)))
     } else if !M::LAZY && port == Port::ERA {
+      self.free_trg(trg);
       Trg::port(Port::ERA)
     } else {
       let n = self.create_node(Op, op as Lab);

--- a/src/run/interact.rs
+++ b/src/run/interact.rs
@@ -259,6 +259,7 @@ impl<'a, M: Mode> Net<'a, M> {
     let a1 = a.p1.load_target();
     if a1.tag() == Num {
       self.rwts.oper += 1;
+      self.half_free(a.p1.addr());
       let out = op.op(b.num(), a1.num());
       self.link_wire_port(a.p2, Port::new_num(out));
     } else {

--- a/src/run/linker.rs
+++ b/src/run/linker.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use super::*;
 
 /// Stores extra data needed about the nodes when in lazy mode. (In strict mode,
@@ -18,7 +20,7 @@ pub(super) struct Header {
 /// non-atomically (because they must be locked).
 pub struct Linker<'h, M: Mode> {
   pub(super) allocator: Allocator<'h>,
-  pub redexes: Vec<(Port, Port)>,
+  pub redexes: VecDeque<(Port, Port)>,
   pub rwts: Rewrites,
   headers: IntMap<Addr, Header>,
   _mode: PhantomData<M>,
@@ -30,7 +32,7 @@ impl<'h, M: Mode> Linker<'h, M> {
   pub fn new(heap: &'h Heap) -> Self {
     Linker {
       allocator: Allocator::new(heap),
-      redexes: Vec::new(),
+      redexes: VecDeque::new(),
       rwts: Default::default(),
       headers: Default::default(),
       _mode: PhantomData,
@@ -89,7 +91,7 @@ impl<'h, M: Mode> Linker<'h, M> {
     if a.is_skippable() && b.is_skippable() {
       self.rwts.eras += 1;
     } else if !M::LAZY {
-      self.redexes.push((a, b));
+      self.redexes.push_back((a, b));
     } else {
       self.set_header(a.clone(), b.clone());
       self.set_header(b.clone(), a.clone());

--- a/src/run/linker.rs
+++ b/src/run/linker.rs
@@ -371,8 +371,8 @@ impl RedexQueue {
     self.fast.is_empty() && self.slow.is_empty()
   }
   #[inline(always)]
-  pub fn take(&mut self) -> impl Iterator<Item = (Port, Port)> {
-    std::mem::take(&mut self.fast).into_iter().chain(std::mem::take(&mut self.slow))
+  pub fn drain(&mut self) -> impl Iterator<Item = (Port, Port)> + '_ {
+    self.fast.drain(..).chain(self.slow.drain(..))
   }
   #[inline(always)]
   pub fn iter(&self) -> impl Iterator<Item = &(Port, Port)> {
@@ -392,7 +392,6 @@ impl RedexQueue {
 // Returns whether a redex does not allocate memory
 fn redex_would_shrink(a: &Port, b: &Port) -> bool {
   (*a == Port::ERA || *b == Port::ERA)
-    || (!(a.tag() == Tag::Ref || b.tag() == Tag::Ref)
-      && (((a.tag() == Tag::Ctr && b.tag() == Tag::Ctr) || a.lab() == b.lab())
-        || (a.tag() == Tag::Num || b.tag() == Tag::Num)))
+    || (a.tag() == Tag::Ctr && b.tag() == Tag::Ctr && a.lab() == b.lab())
+    || (!(a.tag() == Tag::Ref || b.tag() == Tag::Ref) && (a.tag() == Tag::Num || b.tag() == Tag::Num))
 }

--- a/src/run/net.rs
+++ b/src/run/net.rs
@@ -44,7 +44,7 @@ impl<'a, M: Mode> Net<'a, M> {
   pub fn reduce(&mut self, limit: usize) -> usize {
     assert!(!M::LAZY);
     let mut count = 0;
-    while let Some((a, b)) = self.redexes.pop() {
+    while let Some((a, b)) = self.redexes.pop_front() {
       self.interact(a, b);
       count += 1;
       if count >= limit {

--- a/src/run/net.rs
+++ b/src/run/net.rs
@@ -44,7 +44,8 @@ impl<'a, M: Mode> Net<'a, M> {
   pub fn reduce(&mut self, limit: usize) -> usize {
     assert!(!M::LAZY);
     let mut count = 0;
-    while let Some((a, b)) = self.redexes.pop_front() {
+
+    while let Some((a, b)) = self.redexes.pop() {
       self.interact(a, b);
       count += 1;
       if count >= limit {

--- a/src/run/net.rs
+++ b/src/run/net.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// An interaction combinator net.
 pub struct Net<'a, M: Mode> {
-  linker: Linker<'a, M>,
+  pub(super) linker: Linker<'a, M>,
   pub tid: usize,  // thread id
   pub tids: usize, // thread count
   pub trgs: Box<[MaybeUninit<Trg>]>,

--- a/src/run/parallel.rs
+++ b/src/run/parallel.rs
@@ -128,8 +128,8 @@ impl<'h, M: Mode> Net<'h, M> {
         let recv = std::cmp::min(recv, SHARE_LIMIT);
         for i in 0 .. send {
           let init = a_len - send * 2;
-          let rdx0 = ctx.net.redexes.get_unchecked(init + i * 2 + 0).clone();
-          let rdx1 = ctx.net.redexes.get_unchecked(init + i * 2 + 1).clone();
+          let rdx0 = ctx.net.redexes[init + i * 2 + 0].clone();
+          let rdx1 = ctx.net.redexes[init + i * 2 + 1].clone();
           //let init = 0;
           //let ref0 = ctx.net.redexes.get_unchecked_mut(init + i * 2 + 0);
           //let rdx0 = *ref0;
@@ -138,7 +138,7 @@ impl<'h, M: Mode> Net<'h, M> {
           //let rdx1 = *ref1;
           //*ref1    = (Ptr(0), Ptr(0));
           let targ = ctx.share.get_unchecked(b_tid * SHARE_LIMIT + i);
-          *ctx.net.redexes.get_unchecked_mut(init + i) = rdx0;
+          ctx.net.redexes[init + i] = rdx0;
           targ.0.store(rdx1.0.0, Relaxed);
           targ.1.store(rdx1.1.0, Relaxed);
         }
@@ -146,7 +146,7 @@ impl<'h, M: Mode> Net<'h, M> {
         ctx.barry.wait();
         for i in 0 .. recv {
           let got = ctx.share.get_unchecked(a_tid * SHARE_LIMIT + i);
-          ctx.net.redexes.push((Port(got.0.load(Relaxed)), Port(got.1.load(Relaxed))));
+          ctx.net.redexes.push_back((Port(got.0.load(Relaxed)), Port(got.1.load(Relaxed))));
         }
       }
     }

--- a/src/transform/pre_reduce.rs
+++ b/src/transform/pre_reduce.rs
@@ -143,7 +143,7 @@ impl<'a> State<'a> {
     self.rewrites += rt.rwts;
 
     // Move interactions with inert defs back into the net redexes array
-    rt.redexes.extend(self.captured_redexes.lock().unwrap().drain(..));
+    self.captured_redexes.lock().unwrap().drain(..).for_each(|r| rt.redux(r.0, r.1));
 
     let net = self.host.readback(&mut rt);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -91,9 +91,14 @@ fn test_run(name: &str, host: Arc<Mutex<Host>>) {
 fn test_pre_reduce_run(path: &str, mut book: Book) {
   print!("{path}...");
   print!(" pre-reduce");
-  let pre_stats = book.pre_reduce(&|x| x == "main", None, u64::MAX);
-  let host = hvmc::stdlib::create_host(&book);
+  io::stdout().flush().unwrap();
 
+  let start = Instant::now();
+  let pre_stats = book.pre_reduce(&|x| x == "main", None, u64::MAX);
+  print!(" {:.3?}...", start.elapsed());
+  io::stdout().flush().unwrap();
+
+  let host = hvmc::stdlib::create_host(&book);
   let Some((mut rwts, net)) = execute_host(host) else {
     assert_snapshot!(show_rewrites(&pre_stats.rewrites));
     return;


### PR DESCRIPTION
Fixes #91 

- adds some missing calls to `half_free`
- switches from a stack to a queue for the redex bag, ensuring that reductions are processed in an memory-friendly order

I can now run the program in #91 with 1G of memory for 2^28, and with only 1K of memory when single-threaded.

@Janiczek can you confirm this fixes it for you?