### PR TITLE
rework heap allocation api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
 name = "hvm-core"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "arrayvec",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvm-core"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 description = "HVM-Core is a massively parallel Interaction Combinator evaluator."
 license = "MIT"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -59,7 +59,7 @@ fn run_file(path: &PathBuf, group: Option<String>, c: &mut Criterion) {
 }
 
 fn benchmark(file_name: &str, book: Book, c: &mut Criterion) {
-  let area = Heap::new_words(1 << 29);
+  let area = Heap::new(None).unwrap();
   let host = create_host(&book);
   c.bench_function(file_name, |b| {
     b.iter(|| {
@@ -71,7 +71,7 @@ fn benchmark(file_name: &str, book: Book, c: &mut Criterion) {
 }
 
 fn benchmark_group(file_name: &str, group: String, book: Book, c: &mut Criterion) {
-  let area = Heap::new_words(1 << 29);
+  let area = Heap::new(None).unwrap();
   let host = create_host(&book);
 
   c.benchmark_group(group).bench_function(file_name, |b| {
@@ -110,7 +110,7 @@ fn interact_benchmark(c: &mut Criterion) {
   for (name, redex) in cases {
     let mut book = Book::default();
     book.insert("main".to_string(), Net { root: Era, redexes: vec![redex] });
-    let area = Heap::new_words(1 << 24);
+    let area = Heap::new(None).unwrap();
     let host = create_host(&book);
     group.bench_function(name, |b| {
       b.iter(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,11 +160,11 @@ struct TransformOpts {
   /// and don't have side effects this is usually the entry point of the
   /// program (otherwise, the whole program will get reduced to normal form).
   pre_reduce_skip: Vec<String>,
-  #[arg(long = "pre-reduce-memory", default_value = "500M", value_parser = parse_abbrev_number::<usize>)]
+  #[arg(long = "pre-reduce-memory", value_parser = parse_abbrev_number::<usize>)]
   /// How much memory to allocate when pre-reducing.
   ///
   /// Supports abbreviations such as '4G' or '400M'.
-  pre_reduce_memory: usize,
+  pre_reduce_memory: Option<usize>,
   #[arg(long = "pre-reduce-rewrites", default_value = "100M", value_parser = parse_abbrev_number::<u64>)]
   /// Maximum amount of rewrites to do when pre-reducing.
   ///
@@ -187,11 +187,11 @@ struct RuntimeOpts {
   /// by a walk from the root of the net. This leads to a dramatic slowdown,
   /// but allows running programs that would expand indefinitely otherwise.
   lazy_mode: bool,
-  #[arg(short = 'm', long = "memory", default_value = "1G", value_parser = parse_abbrev_number::<usize>)]
+  #[arg(short = 'm', long = "memory", value_parser = parse_abbrev_number::<usize>)]
   /// How much memory to allocate on startup.
   ///
   /// Supports abbreviations such as '4G' or '400M'.
-  memory: usize,
+  memory: Option<usize>,
 }
 #[derive(Args, Clone, Debug)]
 struct RunArgs {
@@ -344,7 +344,7 @@ fn load_book(files: &[String], transform_opts: &TransformOpts) -> Book {
 }
 
 fn reduce_exprs(host: &Host, exprs: &[Net], opts: &RuntimeOpts) {
-  let heap = run::Heap::new_bytes(opts.memory);
+  let heap = run::Heap::new(opts.memory).expect("memory allocation failed");
   for expr in exprs {
     let mut net = DynNet::new(&heap, opts.lazy_mode);
     dispatch_dyn_net!(&mut net => {

--- a/src/run/allocator.rs
+++ b/src/run/allocator.rs
@@ -14,7 +14,8 @@ pub(super) struct Node(pub AtomicU64, pub AtomicU64);
 pub struct Heap(pub(super) [Node]);
 
 impl Heap {
-  /// Allocates a new heap with at most the given size in bytes.
+  /// Allocates a new heap with the given size in bytes, defaulting to the
+  /// largest power-of-two allocation the system will allow.
   pub fn new(bytes: Option<usize>) -> Option<Box<Self>> {
     if let Some(bytes) = bytes {
       return Self::new_exact(bytes / 8);

--- a/src/run/allocator.rs
+++ b/src/run/allocator.rs
@@ -14,21 +14,38 @@ pub(super) struct Node(pub AtomicU64, pub AtomicU64);
 pub struct Heap(pub(super) [Node]);
 
 impl Heap {
-  #[inline]
-  /// Allocate a new heap with a given size in words.
-  pub fn new_words(words: usize) -> Box<Self> {
-    let nodes = words / 2;
-    unsafe {
-      Box::from_raw(core::ptr::slice_from_raw_parts_mut(
-        alloc::alloc(Layout::array::<Node>(nodes).unwrap()) as *mut _,
-        nodes,
-      ) as *mut _)
+  /// Allocates a new heap with at most the given size in bytes.
+  pub fn new(bytes: Option<usize>) -> Option<Box<Self>> {
+    if let Some(bytes) = bytes {
+      return Self::new_exact(bytes / 8);
     }
+    let mut size = if cfg!(target_pointer_width = "64") {
+      1 << 40 // 1 TiB
+    } else {
+      1 << 30 // 1 GiB
+    } / 8;
+    while size != 0 {
+      if let Some(heap) = Self::new_exact(size) {
+        return Some(heap);
+      }
+      size /= 2;
+    }
+    None
   }
-  #[inline(always)]
-  /// Allocate a new heap with a given size in bytes.
-  pub fn new_bytes(bytes: usize) -> Box<Self> {
-    Heap::new_words(bytes / 8)
+  /// Allocates a new heap with exactly the given size in words.
+  #[inline]
+  pub fn new_exact(words: usize) -> Option<Box<Self>> {
+    let nodes = words / 2;
+    if nodes == 0 {
+      return None;
+    }
+    unsafe {
+      let ptr = alloc::alloc(Layout::array::<Node>(nodes).unwrap()) as *mut Node;
+      if ptr.is_null() {
+        return None;
+      }
+      Some(Box::from_raw(core::ptr::slice_from_raw_parts_mut(ptr, nodes) as *mut _))
+    }
   }
 }
 

--- a/src/transform/pre_reduce.rs
+++ b/src/transform/pre_reduce.rs
@@ -33,14 +33,19 @@ impl Book {
   /// Defs that are not in the book are treated as inert defs.
   ///
   /// `max_memory` is measured in words.
-  pub fn pre_reduce(&mut self, skip: &dyn Fn(&str) -> bool, max_memory: usize, max_rwts: u64) -> PreReduceStats {
+  pub fn pre_reduce(
+    &mut self,
+    skip: &dyn Fn(&str) -> bool,
+    max_memory: Option<usize>,
+    max_rwts: u64,
+  ) -> PreReduceStats {
     let mut host = Host::default();
     let captured_redexes = Arc::new(Mutex::new(Vec::new()));
     // When a ref is not found in the `Host`, put an inert def in its place.
     host.insert_book_with_default(self, &mut |_| {
       DefRef::Owned(Box::new(Def::new(LabSet::ALL, InertDef(captured_redexes.clone()))))
     });
-    let area = run::Heap::new_words(max_memory);
+    let area = run::Heap::new(max_memory).expect("pre-reduce memory allocation failed");
 
     let mut state = State {
       book: self,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -203,7 +203,7 @@ fn test_cli_errors() {
 fn test_apply_tree() {
   use hvmc::run;
   fn eval_with_args(fun: &str, args: &[&str]) -> Net {
-    let area = run::Heap::new_words(16);
+    let area = run::Heap::new_exact(16).unwrap();
 
     let mut fun: Net = fun.parse().unwrap();
     for arg in args {

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -18,7 +18,7 @@ fn fuzz_var_link_link_var() {
   trace::set_hook();
   Fuzzer::default().fuzz(|fuzz| {
     unsafe { trace::_reset_traces() };
-    let heap = Heap::new_words(16);
+    let heap = Heap::new_exact(16).unwrap();
     let mut net = Net::new(&heap);
     let x = net.alloc();
     let y = net.alloc();
@@ -63,7 +63,7 @@ fn fuzz_pri_link_link_pri() {
     unsafe { trace::_reset_traces() };
     let p = Port::new(Tag::Ctr, 0, Addr::NULL);
     let q = Port::new(Tag::Ctr, 1, Addr::NULL);
-    let heap = Heap::new_words(16);
+    let heap = Heap::new_exact(16).unwrap();
     let mut net = Net::new(&heap);
     let x = net.alloc();
     let a = Port::new_var(x.clone());
@@ -92,7 +92,7 @@ fn fuzz_pri_link_link_pri() {
 fn fuzz_var_link_link_pri() {
   assert!(cfg!(not(feature = "_fuzz_no_free")));
   trace::set_hook();
-  let heap = Heap::new_words(16);
+  let heap = Heap::new_exact(16).unwrap();
   Fuzzer::default().fuzz(|fuzz| {
     unsafe { trace::_reset_traces() };
     let mut net = Net::new(&heap);
@@ -133,7 +133,7 @@ fn fuzz_var_link_link_pri() {
 fn fuzz_var_link_link_link_var() {
   assert!(cfg!(feature = "_fuzz_no_free"));
   trace::set_hook();
-  let heap = Heap::new_words(16);
+  let heap = Heap::new_exact(16).unwrap();
   Fuzzer::default().fuzz(|fuzz| {
     unsafe { trace::_reset_traces() };
     let mut net = Net::new(&heap);

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -30,7 +30,7 @@ fn test_list_got() {
 
   for index in [0, 1, 3, 7, 15, 31] {
     let book = list_got(index);
-    let (rwts, _) = normal(book, 2048);
+    let (rwts, _) = normal(book, None);
     rwts_list.push(rwts.total())
   }
 
@@ -55,7 +55,7 @@ fn test_list_put() {
 
   for (index, value) in [(0, 2), (1, 4), (3, 8), (7, 16), (15, 32), (31, 0)] {
     let book = list_put(index, value);
-    let (rwts, _) = normal(book, 2048);
+    let (rwts, _) = normal(book, None);
     rwts_list.push(rwts.total())
   }
 

--- a/tests/loaders/mod.rs
+++ b/tests/loaders/mod.rs
@@ -22,8 +22,8 @@ pub fn replace_template(mut code: String, map: &[(&str, &str)]) -> String {
   code
 }
 
-pub fn normal_with(book: Book, words: usize, entry_point: &str) -> (hvmc::run::Rewrites, Net) {
-  let area = run::Heap::new_words(words);
+pub fn normal_with(book: Book, mem: Option<usize>, entry_point: &str) -> (hvmc::run::Rewrites, Net) {
+  let area = run::Heap::new(mem).unwrap();
   let host = create_host(&book);
 
   let mut rnet = run::Net::<run::Strict>::new(&area);
@@ -34,6 +34,6 @@ pub fn normal_with(book: Book, words: usize, entry_point: &str) -> (hvmc::run::R
   (rnet.rwts, net)
 }
 
-pub fn normal(book: Book, words: usize) -> (hvmc::run::Rewrites, Net) {
-  normal_with(book, words, "main")
+pub fn normal(book: Book, mem: Option<usize>) -> (hvmc::run::Rewrites, Net) {
+  normal_with(book, mem, "main")
 }

--- a/tests/numeric.rs
+++ b/tests/numeric.rs
@@ -16,7 +16,7 @@ fn op_net(lnum: u32, op: Op, rnum: u32) -> Book {
 #[test]
 fn test_add() {
   let net = op_net(10, Op::Add, 2);
-  let (rwts, net) = normal(net, 16);
+  let (rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#12");
   assert_debug_snapshot!(rwts.total(), @"3");
 }
@@ -24,98 +24,98 @@ fn test_add() {
 #[test]
 fn test_sub() {
   let net = op_net(10, Op::Sub, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#8");
 }
 
 #[test]
 fn test_mul() {
   let net = op_net(10, Op::Mul, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#20");
 }
 
 #[test]
 fn test_div() {
   let net = op_net(10, Op::Div, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#5");
 }
 
 #[test]
 fn test_mod() {
   let net = op_net(10, Op::Mod, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#0");
 }
 
 #[test]
 fn test_eq() {
   let net = op_net(10, Op::Eq, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#0");
 }
 
 #[test]
 fn test_ne() {
   let net = op_net(10, Op::Ne, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#1");
 }
 
 #[test]
 fn test_lt() {
   let net = op_net(10, Op::Lt, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#0");
 }
 
 #[test]
 fn test_gt() {
   let net = op_net(10, Op::Gt, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#1");
 }
 
 #[test]
 fn test_and() {
   let net = op_net(10, Op::And, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#2");
 }
 
 #[test]
 fn test_or() {
   let net = op_net(10, Op::Or, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#10");
 }
 
 #[test]
 fn test_xor() {
   let net = op_net(10, Op::Xor, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#8");
 }
 
 #[test]
 fn test_lsh() {
   let net = op_net(10, Op::Shl, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#40");
 }
 
 #[test]
 fn test_rsh() {
   let net = op_net(10, Op::Shr, 2);
-  let (_rwts, net) = normal(net, 16);
+  let (_rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#2");
 }
 
 #[test]
 fn test_div_by_0() {
   let net = op_net(9, Op::Div, 0);
-  let (rwts, net) = normal(net, 16);
+  let (rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"#0");
   assert_debug_snapshot!(rwts.total(), @"3");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,7 +23,7 @@ use serial_test::serial;
 #[test]
 fn test_era_era() {
   let net = parse_core("@main = * & * ~ *");
-  let (rwts, net) = normal(net, 16);
+  let (rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"*");
   assert_debug_snapshot!(rwts.total(), @"3");
 }
@@ -31,7 +31,7 @@ fn test_era_era() {
 #[test]
 fn test_era_era2() {
   let net = parse_core("@main = (* *) & * ~ *");
-  let (rwts, net) = normal(net, 16);
+  let (rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"(* *)");
   assert_debug_snapshot!(rwts.total(), @"5");
 }
@@ -39,7 +39,7 @@ fn test_era_era2() {
 #[test]
 fn test_commutation() {
   let net = parse_core("@main = root & (x x) ~ [* root]");
-  let (rwts, net) = normal(net, 16);
+  let (rwts, net) = normal(net, Some(128));
   assert_snapshot!(Net::to_string(&net), @"(a a)");
   assert_debug_snapshot!(rwts.total(), @"7");
 }
@@ -54,14 +54,14 @@ fn test_bool_and() {
     @main = root & @and ~ (@true (@false root))
   ",
   );
-  let (rwts, net) = normal(book, 64);
+  let (rwts, net) = normal(book, Some(128));
 
   assert_snapshot!(Net::to_string(&net), @"(* (a a))");
   assert_debug_snapshot!(rwts.total(), @"14");
 }
 
 fn execute_host(host: Arc<Mutex<Host>>) -> Option<(run::Rewrites, Net)> {
-  let heap = run::Heap::new_words(1 << 29);
+  let heap = run::Heap::new(None).unwrap();
   let mut net = run::Net::<Strict>::new(&heap);
   // The host is locked inside this block.
   {
@@ -91,7 +91,7 @@ fn test_run(name: &str, host: Arc<Mutex<Host>>) {
 fn test_pre_reduce_run(path: &str, mut book: Book) {
   print!("{path}...");
   print!(" pre-reduce");
-  let pre_stats = book.pre_reduce(&|_| false, 1 << 29, u64::MAX);
+  let pre_stats = book.pre_reduce(&|_| false, None, u64::MAX);
   let host = hvmc::stdlib::create_host(&book);
 
   let Some((mut rwts, net)) = execute_host(host) else {

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -12,12 +12,12 @@ pub fn test_fast_pre_reduce() {
   let book = parse_core(&load_file("heavy_pre_reduction.hvmc"));
   let (mut book_1, mut book_2) = (book.clone(), book);
 
-  let rwts_1 = book_1.pre_reduce(&|x| !["expensive", "main_fast"].contains(&x), 1 << 29, u64::MAX).rewrites;
+  let rwts_1 = book_1.pre_reduce(&|x| !["expensive", "main_fast"].contains(&x), None, u64::MAX).rewrites;
   let rwts_2 =
-    book_2.pre_reduce(&|x| !["expensive_1", "expensive_2", "main_slow"].contains(&x), 1 << 29, u64::MAX).rewrites;
+    book_2.pre_reduce(&|x| !["expensive_1", "expensive_2", "main_slow"].contains(&x), None, u64::MAX).rewrites;
 
-  let rwts_1 = show_rewrites(&(rwts_1 + normal_with(book_1, 1 << 29, "main_fast").0));
-  let rwts_2 = show_rewrites(&(rwts_2 + normal_with(book_2, 1 << 29, "main_slow").0));
+  let rwts_1 = show_rewrites(&(rwts_1 + normal_with(book_1, None, "main_fast").0));
+  let rwts_2 = show_rewrites(&(rwts_2 + normal_with(book_2, None, "main_slow").0));
 
   assert_snapshot!(format!("Fast:\n{rwts_1}Slow:\n{rwts_2}"), @r###"
   Fast:


### PR DESCRIPTION
- Fixes UB when heap allocation fails
- When no memory cap is passed, attempts to allocate 1 TiB, and steps down the size until the allocation succeeds
- Simplifies the heap allocation API; there are now two main functions:
  - `Heap::new_exact`, which takes a size in words, and is a useful low-level API for testing/programmatic contexts
  - `Heap::new` is useful for user-controlled heap allocations; it takes an optional size in bytes, and falls back to the try-1-TiB-and-go-down-from-there approach

@FranchuFranchu can you confirm that running hvmc with no arguments works on your machine, still?

Also, @FranchuFranchu thoughts on this new API?