### PR TITLE
Expose normal_from and is_full_node

### DIFF
--- a/src/run/net.rs
+++ b/src/run/net.rs
@@ -60,7 +60,7 @@ impl<'a, M: Mode> Net<'a, M> {
 
   // Lazy mode weak head normalizer
   #[inline(always)]
-  fn weak_normal(&mut self, mut prev: Port, root: Wire) -> Port {
+  pub fn weak_normal(&mut self, mut prev: Port, root: Wire) -> Port {
     assert!(M::LAZY);
 
     let mut path: Vec<Port> = vec![];

--- a/src/run/port.rs
+++ b/src/run/port.rs
@@ -208,7 +208,7 @@ impl Port {
     Port::new(Var, 0, self.addr())
   }
 
-  pub(super) fn is_full_node(&self) -> bool {
+  pub fn is_full_node(&self) -> bool {
     self.tag() > Num
   }
 }


### PR DESCRIPTION
Needed for [hvm-lang/add-debug-mode-for-lazy-evaluation](https://github.com/HigherOrderCO/hvm-lang/tree/feature/sc-536/add-debug-mode-for-lazy-evaluation-in-hvml)