### PR TITLE
Impl Drop for ast::Tree to avoid stack overflows

### DIFF
--- a/src/host/encode.rs
+++ b/src/host/encode.rs
@@ -61,13 +61,14 @@ impl<'a, E: Encoder> State<'a, E> {
     self.visit_tree(tree, trg);
   }
   fn visit_tree(&mut self, tree: &'a Tree, trg: E::Trg) {
+    static ERA: Tree = Tree::Era;
     maybe_grow(move || match tree {
       Tree::Era => self.encoder.link_const(trg, Port::ERA),
       Tree::Num { val } => self.encoder.link_const(trg, Port::new_num(*val)),
       Tree::Ref { nam } => self.encoder.link_const(trg, Port::new_ref(&self.host.defs[nam])),
       Tree::Ctr { lab, ports } => {
         if ports.is_empty() {
-          return self.visit_tree(&Tree::Era, trg);
+          return self.visit_tree(&tree, trg);
         }
         let mut trg = trg;
         for port in &ports[0 .. ports.len() - 1] {
@@ -81,7 +82,7 @@ impl<'a, E: Encoder> State<'a, E> {
         let mut trg = trg;
         for _ in 0 .. *variant_index {
           let (l, r) = self.encoder.ctr(*lab, trg);
-          self.visit_tree(&Tree::Era, l);
+          self.visit_tree(&ERA, l);
           trg = r;
         }
         let (mut l, mut r) = self.encoder.ctr(*lab, trg);
@@ -92,7 +93,7 @@ impl<'a, E: Encoder> State<'a, E> {
         }
         for _ in 0 .. (*variant_count - *variant_index - 1) {
           let (x, y) = self.encoder.ctr(*lab, r);
-          self.visit_tree(&Tree::Era, x);
+          self.visit_tree(&ERA, x);
           r = y;
         }
         self.encoder.link(l, r);

--- a/src/transform/coalesce_ctrs.rs
+++ b/src/transform/coalesce_ctrs.rs
@@ -10,13 +10,13 @@ impl Tree {
     maybe_grow(|| match self {
       Tree::Ctr { lab, ports } => {
         ports.iter_mut().for_each(Tree::coalesce_constructors);
-        match ports.pop() {
-          Some(Tree::Ctr { lab: inner_lab, ports: mut inner_ports })
-            if inner_lab == *lab && ports.len() + inner_ports.len() < MAX_ARITY =>
+        match &mut ports.pop() {
+          Some(Tree::Ctr { lab: inner_lab, ports: inner_ports })
+            if inner_lab == lab && ports.len() + inner_ports.len() < MAX_ARITY =>
           {
             ports.extend(inner_ports.drain(..));
           }
-          Some(other) => ports.push(other),
+          Some(other) => ports.push(std::mem::take(other)),
           None => (),
         }
       }

--- a/src/transform/encode_adts.rs
+++ b/src/transform/encode_adts.rs
@@ -35,10 +35,10 @@ impl Tree {
         }
 
         if let Some((start, idx)) = get_adt_info(lab, ports) {
-          let fields = match ports.swap_remove(idx) {
-            Tree::Ctr { ports: mut fields, .. } => {
+          let fields = match &mut ports.swap_remove(idx) {
+            Tree::Ctr { ports: fields, .. } => {
               fields.pop();
-              fields
+              std::mem::take(fields)
             }
             Tree::Var { .. } => vec![],
             _ => unreachable!(),


### PR DESCRIPTION
I have some tests crashing with a stack overflow in hvm-lang after pre-reduce because the trees get really large for diverging programs.

I copied the implementation of Drop that we have for hvm-lang Terms.

Also adding luna here since she was the one who implemented it in hvm-lang