### PR TITLE
modify compilation strategy to allow for io defs

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -29,7 +29,7 @@ fn _compile_host(host: &Host) -> Result<String, fmt::Error> {
   writeln!(code, "#![allow(non_camel_case_types, unused_imports, unused_variables)]")?;
   writeln!(
     code,
-    "use crate::{{host::{{Host, DefRef}}, stdlib::{{AsHostedDef, HostedDef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};"
+    "use crate::{{host::Host, stdlib::{{AsHostedDef, HostedDef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};"
   )?;
   writeln!(code)?;
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,10 +1,12 @@
 #![cfg(feature = "std")]
 
+use alloc::collections::BTreeSet;
+
 use crate::prelude::*;
 
 use crate::{
   host::Host,
-  run::{Instruction, InterpretedDef, LabSet, Port, Tag},
+  run::{Def, Instruction, InterpretedDef, LabSet, Port, Tag},
   stdlib::HostedDef,
 };
 use core::{fmt::Write, hash::Hasher};
@@ -25,39 +27,91 @@ fn _compile_host(host: &Host) -> Result<String, fmt::Error> {
     .map(|(raw_name, def)| (raw_name, sanitize_name(raw_name), def));
 
   writeln!(code, "#![allow(non_upper_case_globals, unused_imports)]")?;
-  writeln!(code, "use crate::{{host::{{Host, DefRef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};")?;
+  writeln!(
+    code,
+    "use crate::{{host::{{Host, DefRef}}, stdlib::{{AsHostedDef, HostedDef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};"
+  )?;
   writeln!(code)?;
 
-  writeln!(code, "pub fn host() -> Host {{")?;
-  writeln!(code, "  let mut host = Host::default();")?;
-  for (raw_name, name, _) in defs.clone() {
-    writeln!(code, r##"  host.insert_def(r#"{raw_name}"#, DefRef::Static(unsafe {{ &*DEF_{name} }}));"##)?;
-  }
-  writeln!(code, "  host")?;
-  writeln!(code, "}}\n")?;
+  writeln!(code, "pub fn insert_into_host(host: &mut Host) {{")?;
 
-  for (_, name, def) in defs.clone() {
+  // insert empty defs
+  for (hvmc_name, rust_name, def) in defs.clone() {
     let labs = compile_lab_set(&def.labs)?;
     writeln!(
       code,
-      "pub const DEF_{name}: *const Def = const {{ &Def::new({labs}, (call_{name}, call_{name})) }}.upcast();"
+      r##"  host.insert_def(r#"{hvmc_name}"#, unsafe {{ HostedDef::<Def_{rust_name}>::new({labs}) }});"##
+    )?;
+  }
+  writeln!(code)?;
+
+  // hoist all unique refs present in the right hand side of some def
+  for hvmc_name in defs.clone().flat_map(|(_, _, def)| refs(host, &def.data.0.instr)).collect::<BTreeSet<_>>() {
+    let rust_name = sanitize_name(hvmc_name);
+
+    writeln!(code, r##"  let def_{rust_name} = Port::new_ref(&host.defs[r#"{hvmc_name}"#]);"##)?;
+  }
+  writeln!(code)?;
+
+  // initialize each def with the refs it makes use of
+  for (hvmc_name, rust_name, def) in defs.clone() {
+    let refs =
+      refs(host, &def.data.0.instr).iter().map(|r| format!("def_{}", sanitize_name(r))).collect::<Vec<_>>().join(", ");
+
+    writeln!(
+      code,
+      r##"  host.get_mut::<HostedDef<Def_{rust_name}>>(r#"{hvmc_name}"#).data.0 = Def_{rust_name} {{ {refs} }};"##
     )?;
   }
 
+  writeln!(code, "}}")?;
   writeln!(code)?;
 
-  for (_, name, def) in defs {
-    compile_def(&mut code, host, &name, &def.data.0.instr)?;
+  for (_, rust_name, def) in defs.clone() {
+    compile_struct(&mut code, host, &rust_name, def)?;
   }
 
   Ok(code)
 }
 
-fn compile_def(code: &mut String, host: &Host, name: &str, instr: &[Instruction]) -> fmt::Result {
-  writeln!(code, "pub fn call_{name}<M: Mode>(net: &mut Net<M>, to: Port) {{")?;
-  writeln!(code, "  let t0 = Trg::port(to);")?;
-  for instr in instr {
-    write!(code, "  ")?;
+fn refs<'a>(host: &'a Host, instructions: &'a [Instruction]) -> BTreeSet<&'a str> {
+  let mut refs = BTreeSet::new();
+
+  for instr in instructions {
+    if let Instruction::Const { port, .. } | Instruction::LinkConst { port, .. } = instr {
+      if port.tag() == Tag::Ref {
+        refs.insert(host.back[&port.addr()].as_str());
+      }
+    }
+  }
+
+  refs
+}
+
+fn compile_struct(
+  code: &mut String,
+  host: &Host,
+  rust_name: &str,
+  def: &Def<HostedDef<InterpretedDef>>,
+) -> fmt::Result {
+  let refs = refs(host, &def.data.0.instr)
+    .iter()
+    .map(|r| format!("def_{}: Port", sanitize_name(r)))
+    .collect::<Vec<_>>()
+    .join(",\n  ");
+
+  writeln!(code, "#[derive(Default)]")?;
+  writeln!(code, "struct Def_{rust_name} {{")?;
+  writeln!(code, "  {refs}")?;
+  writeln!(code, "}}")?;
+  writeln!(code)?;
+
+  writeln!(code, "impl AsHostedDef for Def_{rust_name} {{")?;
+  writeln!(code, "  fn call<M: Mode>(slf: &Def<Self>, net: &mut Net<M>, port: Port) {{")?;
+  writeln!(code, "    let t0 = Trg::port(port);")?;
+
+  for instr in &def.data.0.instr {
+    write!(code, "    ")?;
     match instr {
       Instruction::Const { trg, port } => {
         writeln!(code, "let {trg} = Trg::port({});", compile_port(host, port))
@@ -85,8 +139,8 @@ fn compile_def(code: &mut String, host: &Host, name: &str, instr: &[Instruction]
       }
     }?;
   }
+  writeln!(code, "  }}")?;
   writeln!(code, "}}")?;
-  code.write_char('\n')?;
 
   Ok(())
 }
@@ -96,11 +150,11 @@ fn compile_port(host: &Host, port: &Port) -> String {
     "Port::ERA".to_owned()
   } else if port.tag() == Tag::Ref {
     let name = sanitize_name(&host.back[&port.addr()]);
-    format!("Port::new_ref(unsafe {{ &*DEF_{name} }})")
+    format!("slf.data.def_{name}.clone()")
   } else if port.tag() == Tag::Int {
     format!("Port::new_int({})", port.int())
   } else if port.tag() == Tag::F32 {
-    format!("Port::new_float({})", port.float())
+    format!("Port::new_float({:?})", port.float())
   } else {
     unreachable!()
   }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -26,7 +26,7 @@ fn _compile_host(host: &Host) -> Result<String, fmt::Error> {
     .filter_map(|(name, def)| Some((name, def.downcast_ref::<HostedDef<InterpretedDef>>()?)))
     .map(|(raw_name, def)| (raw_name, sanitize_name(raw_name), def));
 
-  writeln!(code, "#![allow(non_upper_case_globals, unused_imports)]")?;
+  writeln!(code, "#![allow(non_camel_case_types, unused_imports, unused_variables)]")?;
   writeln!(
     code,
     "use crate::{{host::{{Host, DefRef}}, stdlib::{{AsHostedDef, HostedDef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -37,7 +37,7 @@ fn _compile_host(host: &Host) -> Result<String, fmt::Error> {
     }
   }
 
-  writeln!(code, "#![allow(non_camel_case_types, unused_imports, unused_variables)]")?;
+  writeln!(code, "#![allow(warnings)]")?;
   writeln!(
     code,
     "use crate::{{host::Host, stdlib::{{AsHostedDef, HostedDef}}, run::*, ops::{{TypedOp, Ty::*, Op::*}}}};"

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -2,6 +2,4 @@
 
 use crate::host::Host;
 
-pub fn host() -> Host {
-  Host::default()
-}
+pub fn insert_into_host(_: &mut Host) {}

--- a/src/host.rs
+++ b/src/host.rs
@@ -91,10 +91,7 @@ impl Host {
     // each of the new defs.
     for (nam, net) in book.iter() {
       let data = self.encode_def(net);
-      match self.defs.get_mut(nam).unwrap() {
-        DefRef::Owned(def) => def.downcast_mut::<HostedDef<InterpretedDef>>().unwrap().data.0 = data,
-        DefRef::Static(_) => unreachable!(),
-      }
+      self.get_mut::<HostedDef<InterpretedDef>>(nam).data.0 = data;
     }
   }
 
@@ -102,5 +99,13 @@ impl Host {
   pub fn insert_def(&mut self, name: &str, def: DefRef) {
     self.back.insert(Port::new_ref(&def).addr(), name.to_owned());
     self.defs.insert(name.to_owned(), def);
+  }
+
+  /// Returns a mutable [`Def`] named `name`.
+  pub fn get_mut<T: Send + Sync + 'static>(&mut self, name: &str) -> &mut Def<T> {
+    match self.defs.get_mut(name).unwrap() {
+      DefRef::Owned(def) => def.downcast_mut().unwrap(),
+      DefRef::Static(_) => unreachable!(),
+    }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,9 @@ fn main() {
     }
   } else {
     let cli = BareCli::parse();
-    let host = hvmc::gen::host();
-    run(Arc::new(Mutex::new(host)), cli.opts, cli.args);
+    let host = create_host(&Book::default());
+    gen::insert_into_host(&mut host.lock());
+    run(host, cli.opts, cli.args);
   }
   if cfg!(feature = "trace") {
     hvmc::trace::_read_traces(usize::MAX);

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -141,6 +141,13 @@ impl<T: AsArcDef> AsDef for ArcDef<T> {
 pub struct HostedDef<T: AsHostedDef>(pub T, PhantomData<()>);
 
 impl<T: AsHostedDef> HostedDef<T> {
+  pub unsafe fn new(labs: LabSet) -> DefRef
+  where
+    T: Default,
+  {
+    Self::new_hosted(labs, T::default())
+  }
+
   pub unsafe fn new_hosted(labs: LabSet, data: T) -> DefRef {
     DefRef::Owned(Box::new(Def::new(labs, HostedDef(data, PhantomData))))
   }


### PR DESCRIPTION
fixes https://github.com/HigherOrderCO/hvm-core/issues/111.

Reorganizes the compilation source so that user-defined defs and stdlib defs are all in the same map, so they can be treated equally when compiling instructions.

Empty defs are created and hoisted to the top of `insert_into_host` to allow for mutually recursive definitions.

Compiled source looks like this:
```rust
#![allow(non_upper_case_globals, unused_imports)]
use crate::{host::{Host, DefRef}, stdlib::{AsHostedDef, HostedDef}, run::*, ops::{TypedOp, Ty::*, Op::*}};

pub fn insert_into_host(host: &mut Host) {
  host.insert_def(r#"sub"#, unsafe { HostedDef::<Def_sub>::new(LabSet::from_bits(&[0x1])) });
  host.insert_def(r#"div"#, unsafe { HostedDef::<Def_div>::new(LabSet::from_bits(&[0x1])) });
  host.insert_def(r#"mul"#, unsafe { HostedDef::<Def_mul>::new(LabSet::from_bits(&[0x1])) });
  host.insert_def(r#"mod"#, unsafe { HostedDef::<Def_mod>::new(LabSet::from_bits(&[0x1])) });
  host.insert_def(r#"main"#, unsafe { HostedDef::<Def_main>::new(LabSet::from_bits(&[0x2b])) });
  host.insert_def(r#"add"#, unsafe { HostedDef::<Def_add>::new(LabSet::from_bits(&[0x1])) });

  let def_div = Port::new_ref(&host.defs[r#"div"#]);
  let def_mod = Port::new_ref(&host.defs[r#"mod"#]);

  host.get_mut::<HostedDef<Def_sub>>(r#"sub"#).data.0 = Def_sub {  };
  host.get_mut::<HostedDef<Def_div>>(r#"div"#).data.0 = Def_div {  };
  host.get_mut::<HostedDef<Def_mul>>(r#"mul"#).data.0 = Def_mul {  };
  host.get_mut::<HostedDef<Def_mod>>(r#"mod"#).data.0 = Def_mod {  };
  host.get_mut::<HostedDef<Def_main>>(r#"main"#).data.0 = Def_main { def_div, def_mod };
  host.get_mut::<HostedDef<Def_add>>(r#"add"#).data.0 = Def_add {  };
}

#[derive(Default)]
struct Def_sub {
  
}

impl AsHostedDef for Def_sub {
  fn call<M: Mode>(slf: &Def<Self>, net: &mut Net<M>, port: Port) {
    let t0 = Trg::port(port);
    let (t1, t2) = net.do_ctr(0, t0);
    let (t3, t4) = net.do_op(TypedOp { ty: U60, op: Sub }, t1);
    let (t5, t6) = net.do_ctr(0, t2);
    net.link_trg(t3, t5);
    net.link_trg(t4, t6);
  }
}

// ...

#[derive(Default)]
struct Def_main {
  def_div: Port,
  def_mod: Port
}

impl AsHostedDef for Def_main {
  fn call<M: Mode>(slf: &Def<Self>, net: &mut Net<M>, port: Port) {
    let t0 = Trg::port(port);
    let (t1, t2) = net.do_ctr(0, t0);
    let (t3, t4) = net.do_ctr(3, t1);
    let (t5, t6) = net.do_ctr(0, t2);
    let (t7, t8) = net.do_ctr(5, t5);
    let (t9, t10) = net.do_ctr(1, t6);
    let t11 = Trg::port(slf.data.def_mod.clone());
    let (t12, t13) = net.do_ctr(0, t11);
    net.link_trg(t4, t12);
    let (t14, t15) = net.do_ctr(0, t13);
    net.link_trg(t8, t14);
    net.link_trg(t10, t15);
    let t16 = Trg::port(slf.data.def_div.clone());
    let (t17, t18) = net.do_ctr(0, t16);
    net.link_trg(t3, t17);
    let (t19, t20) = net.do_ctr(0, t18);
    net.link_trg(t7, t19);
    net.link_trg(t9, t20);
  }
}
```