### PR TITLE
fixes ERA and f32 compilations

### DIFF
--- a/src/run/port.rs
+++ b/src/run/port.rs
@@ -181,6 +181,12 @@ impl Port {
     self.tag() == Tag::Int || self.tag() == Tag::F32
   }
 
+  /// Whether this port is an [`ERA`] port.
+  #[inline(always)]
+  pub fn is_era(&self) -> bool {
+    matches!(*self, Port::ERA)
+  }
+
   /// Accesses the label of this port; this is valid for all non-numeric ports.
   #[inline(always)]
   pub const fn lab(&self) -> Lab {


### PR DESCRIPTION
In #125 and #121 I broke compilation of nets with `ERA` ports and nets with floats respectively. This fixes both.

Specifically,
- when scanning for references in a def, don't consider `ERA` nodes (which have `Ref` as a tag) 
- when printing ports that are floats, handle `NaN`, `inf` and `-inf` appropriately

I should probably add tests for compiling `.hvmc` files with floats...