### PR TITLE
dylib compilation and runtime loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "TSPL",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "arrayvec",
  "clap",
  "insta",
+ "libloading",
  "nohash-hasher",
  "ordered-float",
  "parking_lot",
@@ -335,6 +336,16 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.3",
+]
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ debug = "full"
 TSPL = "0.0.9"
 arrayvec = "0.7.4"
 clap = { version = "4.5.1", features = ["derive"], optional = true }
+libloading = "0.8.3"
 nohash-hasher = { version = "0.2.0" }
 ordered-float = "4.2.0"
 parking_lot = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvm-core"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 description = "HVM-Core is a massively parallel Interaction Combinator evaluator."
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::{env, process::Command};
+
+fn main() {
+  let rustc_version = Command::new(env::var("RUSTC").unwrap()).arg("--version").output().unwrap().stdout;
+  let rustc_version = String::from_utf8(rustc_version).unwrap();
+
+  println!("cargo::rustc-env=RUSTC_VERSION={rustc_version}");
+}

--- a/cspell.json
+++ b/cspell.json
@@ -52,6 +52,7 @@
     "rnet",
     "rnum",
     "rsplit",
+    "rustc",
     "rwts",
     "sigabrt",
     "skippable",

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "dereferencable",
     "dref",
     "dups",
+    "dylib",
     "effectful",
     "fmts",
     "fuzzer",

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
     "dref",
     "dups",
     "dylib",
+    "dylibs",
     "effectful",
     "fmts",
     "fuzzer",

--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,8 @@
     "ilog",
     "inlinees",
     "insta",
+    "libhvmc",
+    "libloading",
     "lldb",
     "lnet",
     "lnum",

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -70,7 +70,11 @@ fn _compile_host(host: &Host) -> Result<String, fmt::Error> {
       continue;
     }
 
-    let fields = refs.iter().map(|r| format!("def_{}", sanitize_name(r))).collect::<Vec<_>>().join(", ");
+    let fields = refs
+      .iter()
+      .map(|r| format!("def_{rust_name}: def_{rust_name}.clone()", rust_name = sanitize_name(r)))
+      .collect::<Vec<_>>()
+      .join(", ");
 
     writeln!(
       code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use hvmc::{
 
 use parking_lot::Mutex;
 use std::{
+  ffi::OsStr,
   fmt::Write,
   fs::{self, File},
   io::{self, BufRead},
@@ -33,10 +34,11 @@ fn main() {
       CliMode::Compile { file, dylib, transform_args, output } => {
         let output = if let Some(output) = output {
           output
-        } else if let Some(file_stem) = file.file_stem() {
-          file_stem.into()
+        } else if let Some("hvmc") = file.extension().and_then(OsStr::to_str) {
+          file.with_extension("")
         } else {
           eprintln!("file missing `.hvmc` extension; explicitly specify an output path with `--output`.");
+
           process::exit(1);
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use hvmc::{
 
 use parking_lot::Mutex;
 use std::{
-  ffi::OsStr,
   fmt::Write,
   fs::{self, File},
   io::{self, BufRead},
@@ -434,11 +433,7 @@ fn insert_crate_type_cargo_toml() -> Result<(), io::Error> {
 }
 
 /// Compiles the `.hvm` directory, appending the provided `args` to `cargo`.
-fn compile_temp_hvm<I, S>(args: I) -> Result<(), io::Error>
-where
-  I: IntoIterator<Item = S>,
-  S: AsRef<OsStr>,
-{
+fn compile_temp_hvm(args: &[&'static str]) -> Result<(), io::Error> {
   let output = process::Command::new("cargo")
     .current_dir(".hvm")
     .arg("build")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use hvmc::{
   ast::{Book, Net, Tree},
   host::Host,
   run::{DynNet, Mode, Trg},
-  stdlib::insert_book,
+  stdlib::{create_host, insert_book},
   transform::{TransformOpts, TransformPass, TransformPasses},
   *,
 };
@@ -40,8 +40,7 @@ fn main() {
           process::exit(1);
         };
 
-        let host: Arc<Mutex<Host>> = Default::default();
-        insert_book(host.clone(), &load_book(&[file], &transform_args));
+        let host = create_host(&load_book(&[file], &transform_args));
         create_temp_hvm(host).unwrap();
 
         if dylib {
@@ -69,8 +68,7 @@ fn main() {
         run(host, run_opts, args);
       }
       CliMode::Reduce { run_opts, transform_args, files, exprs } => {
-        let host: Arc<Mutex<Host>> = Default::default();
-        insert_book(host.clone(), &load_book(&files, &transform_args));
+        let host = create_host(&load_book(&files, &transform_args));
         let exprs: Vec<_> = exprs.iter().map(|x| Net::from_str(x).unwrap()).collect();
         reduce_exprs(host, &exprs, &run_opts);
       }
@@ -81,8 +79,7 @@ fn main() {
     }
   } else {
     let cli = BareCli::parse();
-    let host: Arc<Mutex<Host>> = Default::default();
-    insert_book(host.clone(), &Book::default());
+    let host = create_host(&Book::default());
     gen::insert_into_host(&mut host.lock());
     run(host, cli.opts, cli.args);
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,7 @@ pub fn hvmc_dylib_v0__insert_host(host: &mut host::Host) {{
   fs::remove_file(".hvm/src/main.rs")
 }
 
+/// Adds `crate_type = ["dylib"]` under the `[lib]` section of `Cargo.toml`.
 fn insert_crate_type_cargo_toml() -> Result<(), io::Error> {
   let mut cargo_toml = String::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use hvmc::{
   ast::{Book, Net, Tree},
   host::Host,
   run::{DynNet, Mode, Trg},
-  stdlib::{create_host, insert_book},
+  stdlib::{create_host, insert_stdlib},
   transform::{TransformOpts, TransformPass, TransformPasses},
   *,
 };
@@ -63,7 +63,8 @@ fn main() {
 
         let host: Arc<Mutex<Host>> = Default::default();
         load_dylibs(host.clone(), &args.include);
-        insert_book(host.clone(), &load_book(&[file], &transform_args));
+        insert_stdlib(host.clone());
+        host.lock().insert_book(&load_book(&[file], &transform_args));
 
         run(host, run_opts, args);
       }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use hvmc::{
 
 use parking_lot::Mutex;
 use std::{
+  env::consts::{DLL_EXTENSION, DLL_PREFIX},
   ffi::OsStr,
   fmt::Write,
   fs::{self, File},
@@ -49,9 +50,7 @@ fn main() {
           prepare_temp_hvm_dylib().unwrap();
           compile_temp_hvm(&["--lib"]).unwrap();
 
-          // TODO: this can be a different extension on different platforms
-          // see: https://doc.rust-lang.org/reference/linkage.html
-          fs::copy(".hvm/target/release/libhvmc.so", output).unwrap();
+          fs::copy(format!(".hvm/target/release/{DLL_PREFIX}hvmc.{DLL_EXTENSION}"), output).unwrap();
         } else {
           compile_temp_hvm(&[]).unwrap();
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -70,7 +70,7 @@ pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
   host
 }
 
-/// Create a `Host` from a `Book`, including `hvm-core`'s built-in definitions
+/// Insert `hvm-core`'s built-in definitions into a host.
 #[cfg(feature = "std")]
 #[allow(clippy::absolute_paths)]
 pub fn insert_stdlib(host: Arc<Mutex<Host>>) {

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -64,7 +64,8 @@ impl<F: Fn(Tree) + Clone + Send + Sync + 'static> AsHostedDef for LogDef<F> {
 pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
   let host: Arc<Mutex<Host>> = Default::default();
 
-  insert_book(host.clone(), book);
+  insert_stdlib(host.clone());
+  host.lock().insert_book(book);
 
   host
 }
@@ -72,7 +73,7 @@ pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
 /// Create a `Host` from a `Book`, including `hvm-core`'s built-in definitions
 #[cfg(feature = "std")]
 #[allow(clippy::absolute_paths)]
-pub fn insert_book(host: Arc<Mutex<Host>>, book: &crate::ast::Book) {
+pub fn insert_stdlib(host: Arc<Mutex<Host>>) {
   host.lock().insert_def("HVM.log", unsafe {
     crate::stdlib::LogDef::new(host.clone(), {
       move |tree| {
@@ -81,7 +82,6 @@ pub fn insert_book(host: Arc<Mutex<Host>>, book: &crate::ast::Book) {
     })
   });
   host.lock().insert_def("HVM.black_box", DefRef::Static(unsafe { &*IDENTITY }));
-  host.lock().insert_book(book);
 }
 
 #[repr(transparent)]

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -61,8 +61,7 @@ impl<F: Fn(Tree) + Clone + Send + Sync + 'static> AsHostedDef for LogDef<F> {
 /// Create a `Host` from a `Book`, including `hvm-core`'s built-in definitions
 #[cfg(feature = "std")]
 #[allow(clippy::absolute_paths)]
-pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
-  let host = Arc::new(Mutex::new(Host::default()));
+pub fn insert_book(host: Arc<Mutex<Host>>, book: &crate::ast::Book) {
   host.lock().insert_def("HVM.log", unsafe {
     crate::stdlib::LogDef::new(host.clone(), {
       move |tree| {
@@ -72,7 +71,6 @@ pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
   });
   host.lock().insert_def("HVM.black_box", DefRef::Static(unsafe { &*IDENTITY }));
   host.lock().insert_book(book);
-  host
 }
 
 #[repr(transparent)]

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -61,6 +61,17 @@ impl<F: Fn(Tree) + Clone + Send + Sync + 'static> AsHostedDef for LogDef<F> {
 /// Create a `Host` from a `Book`, including `hvm-core`'s built-in definitions
 #[cfg(feature = "std")]
 #[allow(clippy::absolute_paths)]
+pub fn create_host(book: &crate::ast::Book) -> Arc<Mutex<Host>> {
+  let host: Arc<Mutex<Host>> = Default::default();
+
+  insert_book(host.clone(), book);
+
+  host
+}
+
+/// Create a `Host` from a `Book`, including `hvm-core`'s built-in definitions
+#[cfg(feature = "std")]
+#[allow(clippy::absolute_paths)]
 pub fn insert_book(host: Arc<Mutex<Host>>, book: &crate::ast::Book) {
   host.lock().insert_def("HVM.log", unsafe {
     crate::stdlib::LogDef::new(host.clone(), {


### PR DESCRIPTION
Fixes https://github.com/HigherOrderCO/hvm-core/issues/112.

1. Adds `--dylib` to the `compile` command. Per [The Rust Reference], this will output a "`*.so` file on Linux, `*.dylib` file on macOS, and `*.dll` file on Window."
2. Adds `--include` to the `run` command. A space-delimited list of hvm-core dynamic library files to load before running the provided hvm-core file.
3. Fixes a bug where compiling an hvmc program that uses a single definition multiple times causes a rust error.

Additionally cleans up some `clap` args:
- Changes filepaths from `String` to `PathBuf`.
- Removes explicit `short` and `long` attributes if they are identical to the implicit ones.

Example:
`two-and-three.hvmc`:
```
@two = #2.0
@three = #3.0
```
`two-plus-three.hvmc`:
```
@main = r & @two ~ <f32.+ @three r>
```
Compiling and running:
```bash
$ cargo run -r -- compile two-and-three.hvmc --dylib --output two-and-three.so
$ cargo run -r -- run two-plus-three.hvmc --include two-and-three.so
#5.0
$ cargo run -r -- run two-plus-three.hvmc
thread 'main' panicked at src/host.rs:58:50:
Found reference "two", which is not in the book!
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fish: Job 1, 'cargo run -r -- run two-plus-th…' terminated by signal SIGABRT (Abort)
```

## Notes
Generated dylibs are versioned with the hvmc crate version that was used to compile them. Using a dylib with a version of hvmc that does not match the dylib produces a warning like the following:
```
warning: dylib "f32-defs.dylib" was compiled with hvmc version 0.2.25, but is being run with hvmc version 0.2.26
```

[The Rust Reference]: https://doc.rust-lang.org/reference/linkage.html